### PR TITLE
feat: подкасты — ID3-теги, название шоу, номер эпизода

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Проект
+
+Два независимых компонента в одном репозитории:
+
+1. **Расширение для браузера** (Chromium, Manifest V3) — скачивание с Я.Музыки, Bandcamp, SoundCloud прямо со страницы или по paste-link из попапа.
+2. **Десктопная программа** (`desktop/`) — PySide6 GUI поверх yt-dlp, 1800+ сайтов, кросс-платформенно. `downloader.py` в корне — legacy-версия на tkinter только для Я.Музыки.
+
+## Команды
+
+### Десктоп (Python)
+
+```bash
+cd desktop
+pip install -r requirements.txt
+python main.py                          # запуск GUI
+
+pip install pyinstaller pillow
+python build.py                         # сборка .exe → desktop/dist/MusicDownloader.exe
+```
+
+### Расширение
+
+Нет шага сборки — загружается распакованной папкой через `chrome://extensions` → "Загрузить распакованное".
+
+Проверить валидность `manifest.json`:
+```bash
+python -c "import json; json.load(open('manifest.json'))"
+```
+
+### Релиз
+
+Тег `v*` запускает GitHub Actions (`release.yml`): собирает `.zip` расширения и `.exe` десктопа, публикует Release. Ручной запуск — через `workflow_dispatch` с полем `tag`.
+
+## Архитектура расширения
+
+**Глобальный namespace:** `globalThis.YMD` — инициализируется в `lib/core.js`, доступен во всех скриптах.
+
+**Service registry** (`lib/core.js`):
+- `YMD.registry.register(svc)` — регистрирует адаптер
+- `YMD.registry.detectByUrl(url)` → `{service, parsed}` — автодетект по URL
+- `YMD.registry.detectByHost(hostname)` → service — для in-page кнопок
+
+**Адаптер-паттерн** (каждый файл в `services/`):
+- `parseUrl(url)` → `{type, ...}` | `null`
+- `listTracks(parsed)` → массив треков
+- `getAudioUrl(track, ctx)` → mp3 URL
+- `getFilename(track)` → строка
+- поля `name`, `displayName`, `domains`
+
+**Загрузка скриптов:**
+- `background.js` (Service Worker) — `importScripts(lib/md5.js, lib/core.js, services/*.js)`, координирует скачивание, перехватывает аудио через `chrome.webRequest`
+- `content.js` — content script только для `music.yandex.*`, строит UI на странице (FAB, кнопки на треках, MutationObserver для SPA-навигации). Скрипты для content script перечислены в `manifest.json → content_scripts[0].js`
+
+**Paste-link flow** (`background.js → downloadByUrl`): детект сервиса → `listTracks` → перебор треков → `getAudioUrl` → `chrome.downloads.download`. Прогресс идёт через `chrome.runtime.sendMessage({action: 'pasteProgress', ...})` в `popup.js`.
+
+**Перехват аудио Я.Музыки:** `chrome.webRequest.onBeforeRequest` слушает `*.storage.mds.yandex.net`, `*.strm.yandex.net`, кеширует URL по `tabId` (последние 20, TTL 5 мин). Запрос через `{action: 'getCapturedAudio'}`.
+
+**MD5** (`lib/md5.js`) — используется в `services/yandex.js` для подписи URL аудио.
+
+## Архитектура десктопа
+
+| Файл | Роль |
+|---|---|
+| `main.py` | Entry point |
+| `window.py` | `MainWindow` (PySide6), тема, очередь заданий |
+| `core.py` | `DownloadWorker(QObject)` — работает в `QThread`, сигналы: `info_ready`, `progress`, `done`, `error` |
+| `ffmpeg_helper.py` | Поиск ffmpeg в PATH и рядом с бинарником |
+| `settings.py` | JSON-конфиг (папка, формат, cookies-браузер) |
+| `build.py` | PyInstaller-сборка |
+
+`DownloadWorker` принимает `options` dict: `output_dir`, `audio_only`, `audio_format`, `audio_quality`, `video_format`, `cookies_browser`, `ffmpeg_path`. Опция `cookiesfrombrowser` пробрасывается напрямую в yt-dlp.
+
+## Добавление нового сервиса в расширение
+
+1. Создать `services/newservice.js` — реализовать адаптер и вызвать `YMD.registry.register(...)` в конце.
+2. Добавить домены в `manifest.json → host_permissions`.
+3. Добавить скрипт в `manifest.json → background.service_worker` — нет, background грузит через `importScripts`; добавить в `background.js → importScripts(...)`.
+4. Если нужен in-page UI — добавить в `content_scripts[0].js` и домены в `content_scripts[0].matches`.

--- a/background.js
+++ b/background.js
@@ -54,6 +54,71 @@ function getSaveAs() {
 }
 
 // ═══════════════════════════════════════
+// ID3v2.3 TAG EMBEDDING
+// ═══════════════════════════════════════
+
+function buildID3(tags) {
+  const enc = new TextEncoder();
+  function makeFrame(id, text) {
+    const body = enc.encode(text);
+    const buf = new Uint8Array(4 + 4 + 2 + 1 + body.length);
+    for (let i = 0; i < 4; i++) buf[i] = id.charCodeAt(i);
+    const sz = 1 + body.length;
+    buf[4] = (sz >> 24) & 0xff; buf[5] = (sz >> 16) & 0xff;
+    buf[6] = (sz >> 8) & 0xff;  buf[7] = sz & 0xff;
+    buf[10] = 3; // UTF-8 encoding
+    buf.set(body, 11);
+    return buf;
+  }
+  const frames = [];
+  if (tags.title)       frames.push(makeFrame('TIT2', tags.title));
+  if (tags.artist)      frames.push(makeFrame('TPE1', tags.artist));
+  if (tags.album)       frames.push(makeFrame('TALB', tags.album));
+  if (tags.trackNumber) frames.push(makeFrame('TRCK', String(tags.trackNumber)));
+  if (!frames.length) return null;
+  const sz = frames.reduce((s, f) => s + f.length, 0);
+  const hdr = new Uint8Array([
+    0x49, 0x44, 0x33, 0x03, 0x00, 0x00,  // "ID3" v2.3
+    (sz >> 21) & 0x7f, (sz >> 14) & 0x7f, (sz >> 7) & 0x7f, sz & 0x7f, // synchsafe size
+  ]);
+  const out = new Uint8Array(hdr.length + sz);
+  out.set(hdr);
+  let off = hdr.length;
+  for (const f of frames) { out.set(f, off); off += f.length; }
+  return out;
+}
+
+// Fetches audio, prepends ID3 header, downloads via data URL.
+// URL.createObjectURL is unavailable in MV3 service workers, so we use base64 data URL.
+// Falls back to direct URL if fetch fails.
+async function downloadWithTags(audioUrl, filename, tags, saveAs) {
+  const id3 = (tags?.title || tags?.artist) ? buildID3(tags) : null;
+  if (!id3) return chromeDownload(audioUrl, filename, saveAs);
+  try {
+    const resp = await fetch(audioUrl, {
+      credentials: 'include',
+      headers: { 'Referer': 'https://music.yandex.ru/' },
+    });
+    if (!resp.ok) throw new Error('HTTP ' + resp.status);
+    const audio = await resp.arrayBuffer();
+    const merged = new Uint8Array(id3.length + audio.byteLength);
+    merged.set(id3);
+    merged.set(new Uint8Array(audio), id3.length);
+    // Encode to base64 in chunks to avoid max call stack errors on large files
+    const CHUNK = 0x8000;
+    let binary = '';
+    for (let i = 0; i < merged.length; i += CHUNK) {
+      binary += String.fromCharCode(...merged.subarray(i, i + CHUNK));
+    }
+    const dataUrl = 'data:audio/mpeg;base64,' + btoa(binary);
+    return chromeDownload(dataUrl, filename, saveAs);
+  } catch (e) {
+    console.warn('[YMD] ID3 embed failed, fallback:', e.message);
+    return chromeDownload(audioUrl, filename, saveAs);
+  }
+}
+
+// ═══════════════════════════════════════
 // PASTE-LINK FLOW (cross-service)
 // ═══════════════════════════════════════
 
@@ -97,7 +162,8 @@ async function downloadByUrl(rawUrl) {
       if (!audioUrl) throw new Error('audio URL пустой');
       const filename = service.getFilename(t) || `track.mp3`;
       const fullName = isBatch ? `${folder}/${filename}` : filename;
-      const res = await chromeDownload(audioUrl, fullName, saveAs && !isBatch);
+      const tags = { title: t.title, artist: t.artist, album: t.artist, trackNumber: t.trackNumber };
+      const res = await downloadWithTags(audioUrl, fullName, tags, saveAs && !isBatch);
       if (res.success) downloaded++;
       else console.warn('[YMD] download failed:', res.error);
     } catch (err) {
@@ -124,20 +190,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
 
   if (message.action === 'download') {
-    const url = message.url;
-    const filename = message.filename || 'track.mp3';
+    const { url, filename = 'track.mp3', tags } = message;
     chrome.storage.local.get('saveAs', (data) => {
       const saveAs = !!data.saveAs;
-      chrome.downloads.download({ url, filename, saveAs }, (downloadId) => {
-        if (chrome.runtime.lastError) {
-          if (saveAs) {
-            chrome.downloads.download({ url, saveAs: true }, (id2) => {
-              if (chrome.runtime.lastError) sendResponse({ success: false, error: chrome.runtime.lastError.message });
-              else sendResponse({ success: true, downloadId: id2 });
-            });
-          } else sendResponse({ success: false, error: chrome.runtime.lastError.message });
-        } else sendResponse({ success: true, downloadId });
-      });
+      downloadWithTags(url, filename, tags, saveAs)
+        .then(r => sendResponse(r))
+        .catch(e => sendResponse({ success: false, error: e.message }));
     });
     return true;
   }

--- a/content.js
+++ b/content.js
@@ -91,11 +91,11 @@
   // DOWNLOAD
   // ═══════════════════════════════════════
 
-  async function downloadFile(url, filename) {
+  async function downloadFile(url, filename, tags) {
     console.log('[YMD] Download:', url.substring(0, 80), '→', filename);
     showNotification('Скачиваю: ' + filename, 'loading');
     return new Promise((resolve) => {
-      chrome.runtime.sendMessage({ action: 'download', url, filename }, resp => {
+      chrome.runtime.sendMessage({ action: 'download', url, filename, tags }, resp => {
         if (resp?.success) { resolve({ success: true, filename }); return; }
         // Fallback: fetch + blob (works for CORS-friendly URLs)
         fetch(url)
@@ -116,9 +116,23 @@
   async function downloadCurrentTrack() {
     const info = getCurrentPlayerInfo();
     if (!info.trackId) { showNotification('Включите трек', 'error'); return { success: false, error: 'Нет трека' }; }
-    const fn = (info.artist && info.title)
-      ? `${sanitize(info.artist)} - ${sanitize(info.title)}.mp3`
-      : `track_${info.trackId}.mp3`;
+
+    let title = info.title;
+    let artist = info.artist;
+    let trackNumber = null;
+
+    // Podcast episodes have no artists in DOM — fetch from API to get show name + episode number
+    if (!artist && info.trackId) {
+      try {
+        const tracks = await yandex.listTracks({ type: 'track', trackId: info.trackId, albumId: info.albumId, origin: ORIGIN });
+        const tr = tracks?.[0];
+        if (tr) { artist = artist || tr.artist || ''; title = title || tr.title || ''; trackNumber = tr.trackNumber || null; }
+      } catch { /* use what DOM gave us */ }
+    }
+
+    const fn = (artist && title)
+      ? `${sanitize(artist)} - ${sanitize(title)}.mp3`
+      : (title ? `${sanitize(title)}.mp3` : `track_${info.trackId}.mp3`);
     try {
       showNotification('Получаю аудио...', 'loading');
       const track = { trackId: info.trackId, albumId: info.albumId, origin: ORIGIN };
@@ -127,7 +141,7 @@
         showNotification('Нет URL. Переключите трек и попробуйте снова.', 'error');
         return { success: false, error: 'Нет URL. Переключите трек.' };
       }
-      await downloadFile(audioUrl, fn);
+      await downloadFile(audioUrl, fn, { title, artist, album: artist, trackNumber });
       showNotification('✓ ' + fn, 'success');
       return { success: true, filename: fn };
     } catch (err) {
@@ -137,14 +151,27 @@
   }
 
   async function downloadTrackById(trackId, albumId, titleInfo) {
-    const fn = (titleInfo?.artist && titleInfo?.title)
-      ? `${sanitize(titleInfo.artist)} - ${sanitize(titleInfo.title)}.mp3`
-      : `track_${trackId}.mp3`;
+    let artist = titleInfo?.artist || '';
+    let title = titleInfo?.title || '';
+    let trackNumber = titleInfo?.trackNumber || null;
+
+    // Podcast episodes: DOM gives no artist (show name) — fetch from API
+    if (!artist && albumId) {
+      try {
+        const tracks = await yandex.listTracks({ type: 'track', trackId, albumId, origin: ORIGIN });
+        const tr = tracks?.[0];
+        if (tr) { artist = tr.artist || artist; title = title || tr.title || ''; trackNumber = tr.trackNumber || null; }
+      } catch { /* ignore */ }
+    }
+
+    const fn = (artist && title)
+      ? `${sanitize(artist)} - ${sanitize(title)}.mp3`
+      : (title ? `${sanitize(title)}.mp3` : `track_${trackId}.mp3`);
     try {
       showNotification('Получаю ссылку...', 'loading');
       const audioUrl = await yandex.getAudioUrl({ trackId, albumId, origin: ORIGIN }, {});
       if (audioUrl) {
-        await downloadFile(audioUrl, fn);
+        await downloadFile(audioUrl, fn, { title, artist, album: artist, trackNumber });
         showNotification('✓ ' + fn, 'success');
         return { success: true, filename: fn };
       }

--- a/services/yandex.js
+++ b/services/yandex.js
@@ -13,9 +13,13 @@
     const p = u.pathname;
     let m = p.match(/\/album\/(\d+)\/track\/(\d+)/);
     if (m) return { type: 'track', albumId: m[1], trackId: m[2], origin: u.origin };
+    m = p.match(/\/podcast\/(\d+)\/episode\/(\d+)/);
+    if (m) return { type: 'track', albumId: m[1], trackId: m[2], origin: u.origin };
     m = p.match(/\/track\/(\d+)/);
     if (m) return { type: 'track', albumId: null, trackId: m[1], origin: u.origin };
     m = p.match(/\/album\/(\d+)/);
+    if (m) return { type: 'album', albumId: m[1], origin: u.origin };
+    m = p.match(/\/podcast\/(\d+)/);
     if (m) return { type: 'album', albumId: m[1], origin: u.origin };
     m = p.match(/\/users\/([^/]+)\/playlists\/(\d+)/);
     if (m) return { type: 'playlist', owner: m[1], kinds: m[2], origin: u.origin };
@@ -28,14 +32,23 @@
     });
     if (!resp.ok) throw new Error('Не удалось получить треки альбома');
     const data = await resp.json();
+    // API sometimes wraps album data under data.album, sometimes at data root
+    const album = data.album || data;
+    const showTitle = album.title || data.title || '';
+    console.log('[YMD] fetchAlbumTracks', albumId, 'showTitle:', showTitle, 'volumes:', album.volumes?.length ?? data.volumes?.length);
     const out = [];
-    for (const vol of (data.volumes || [])) {
-      for (const t of vol) {
+    for (const vol of (album.volumes || data.volumes || [])) {
+      // vol is always an array (one per disk), but guard anyway
+      const tracks = Array.isArray(vol) ? vol : [vol];
+      for (const t of tracks) {
+        if (!t?.id) continue;
+        const artists = (t.artists || []).map(a => a.name).join(', ');
         out.push({
           trackId: String(t.id),
           albumId: String(t.albums?.[0]?.id || albumId),
           title: t.title || '',
-          artist: (t.artists || []).map(a => a.name).join(', ') || '',
+          artist: artists || showTitle,
+          trackNumber: t.albums?.[0]?.trackPosition || null,
           origin,
         });
       }
@@ -52,11 +65,14 @@
     const pl = data.playlist || data;
     return (pl.tracks || []).map(t => {
       const tr = t.track || t;
+      const artists = (tr.artists || []).map(a => a.name).join(', ');
+      const showTitle = tr.albums?.[0]?.title || '';
       return {
         trackId: String(tr.id),
         albumId: String(tr.albums?.[0]?.id || ''),
         title: tr.title || '',
-        artist: (tr.artists || []).map(a => a.name).join(', ') || '',
+        artist: artists || showTitle,
+        trackNumber: tr.albums?.[0]?.trackPosition || null,
         origin,
       };
     }).filter(t => t.trackId);
@@ -77,11 +93,14 @@
       if (resp.ok) {
         const data = await resp.json();
         const tr = data.track || data;
+        const artists = (tr.artists || []).map(a => a.name).join(', ');
+        const showTitle = data.album?.title || tr.albums?.[0]?.title || '';
         return {
           trackId: String(trackId),
           albumId: String(tr.albums?.[0]?.id || albumId || ''),
           title: tr.title || '',
-          artist: (tr.artists || []).map(a => a.name).join(', ') || '',
+          artist: artists || showTitle,
+          trackNumber: tr.albums?.[0]?.trackPosition || null,
           origin,
         };
       }


### PR DESCRIPTION
## Что изменилось

### Поддержка подкастов (`services/yandex.js`)
- Название шоу (`data.album.title` или `data.title`) подставляется как artist для эпизодов без исполнителей
- Добавлено поле `trackNumber` из `albums[0].trackPosition` — номер эпизода
- Поддержка URL `/podcast/ID` и `/podcast/ID/episode/ID` в `parseUrl`
- `fetchAlbumTracks` устойчив к разным структурам ответа API (podcast vs album)

### ID3-теги в скачанных файлах (`background.js`)
- Добавлен ID3v2.3 encoder (`buildID3`) — фреймы TIT2, TPE1, TALB, TRCK
- `downloadWithTags` загружает аудио в память, прикрепляет ID3-заголовок и отдаёт через data URL
  (`URL.createObjectURL` недоступен в MV3 service worker — используем base64 data URL)
- Fallback на прямое скачивание если fetch не удался

### Обогащение метаданных in-page (`content.js`)
- `downloadFile` прокидывает теги `{title, artist, album, trackNumber}` в background
- `downloadCurrentTrack` и `downloadTrackById` делают API-запрос для получения названия шоу и номера эпизода, когда DOM не содержит исполнителя (типично для подкастов)

### В итоге для эпизода подкаста:
| Тег | Значение |
|---|---|
| TIT2 (название) | Название эпизода |
| TPE1 (исполнитель) | Название шоу |
| TALB (альбом) | Название шоу |
| TRCK (трек №) | Номер эпизода |

Имя файла: `Название шоу - Название эпизода.mp3`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)