### PR TITLE
v3.2.1: фикс CORS, UUID-плейлистов и авто-захват токена

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Syntax-check JS files
         run: |
           set -e
-          for f in background.js content.js popup.js lib/*.js services/*.js; do
+          for f in background.js content.js popup.js lib/*.js services/*.js inject/*.js; do
             echo "checking $f"
             node --check "$f"
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
             background.js \
             content.js content.css \
             popup.html popup.js popup.css \
-            lib services icons \
+            lib services inject icons \
             README.md
           echo "out=out/${OUT}" >> "$GITHUB_OUTPUT"
           echo "name=${OUT}" >> "$GITHUB_OUTPUT"

--- a/background.js
+++ b/background.js
@@ -23,7 +23,7 @@ chrome.webRequest.onBeforeRequest.addListener(
     const url = details.url;
     const isAudio = AUDIO_PATTERNS.some(p => url.includes(p)) ||
       url.match(/\.(mp3|aac|m4a|opus|ogg)(\?|$)/i) ||
-      (url.includes('storage.mds.yandex.net') && AUDIO_TYPES.includes(details.type));
+      ((url.includes('storage.mds.yandex.net') || url.includes('storage.yandex.net')) && AUDIO_TYPES.includes(details.type));
     if (!isAudio) return;
     const tabId = details.tabId;
     if (tabId < 0) return;
@@ -31,7 +31,16 @@ chrome.webRequest.onBeforeRequest.addListener(
     capturedAudio[tabId].unshift({ url, timestamp: Date.now() });
     if (capturedAudio[tabId].length > 20) capturedAudio[tabId] = capturedAudio[tabId].slice(0, 20);
   },
-  { urls: ['*://*.storage.mds.yandex.net/*', '*://storage.mds.yandex.net/*', '*://*.strm.yandex.net/*'], types: ['media', 'xmlhttprequest', 'other'] }
+  {
+    urls: [
+      '*://*.storage.mds.yandex.net/*',
+      '*://storage.mds.yandex.net/*',
+      '*://*.strm.yandex.net/*',
+      '*://*.storage.yandex.net/*',
+      '*://storage.yandex.net/*',
+    ],
+    types: ['media', 'xmlhttprequest', 'other'],
+  }
 );
 
 chrome.tabs.onRemoved.addListener((tabId) => { delete capturedAudio[tabId]; });
@@ -163,6 +172,21 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         else sendResponse(resp || { success: false });
       });
     });
+    return true;
+  }
+
+  if (message.action === 'corsProxyFetch') {
+    // Кросс-доменный fetch из background (host_permissions обходят CORS).
+    // Используется для storage.mds.yandex.net и подобных хостов которые не дают CORS.
+    const url = message.url;
+    const headers = message.headers || {};
+    fetch(url, { headers })
+      .then(async (r) => {
+        const body = await r.text();
+        if (!r.ok) sendResponse({ ok: false, error: `HTTP ${r.status}`, status: r.status, body });
+        else sendResponse({ ok: true, status: r.status, body });
+      })
+      .catch(e => sendResponse({ ok: false, error: e.message || String(e) }));
     return true;
   }
 

--- a/content.js
+++ b/content.js
@@ -326,31 +326,35 @@
   }
 
   // ═══════════════════════════════════════
-  // YANDEX MUSIC TOKEN AUTO-GRAB
+  // YANDEX MUSIC TOKEN AUTO-CAPTURE
   // ═══════════════════════════════════════
-  // Я.Музыка снесла свой web-API в 2026 — теперь API на api.music.yandex.net
-  // требует OAuth-токен. Если юзер залогинен на music.yandex.ru, токен можно
-  // достать из state-снапшота страницы / localStorage. Если не получилось —
-  // пользователь вводит токен вручную в попапе.
+  // Я.Музыка снесла свой старый веб-API в 2026 — теперь API на api.music.yandex.net
+  // требует OAuth-токен. inject/yam-fetch-hook.js (MAIN world, document_start)
+  // оборачивает fetch+XHR на странице, перехватывает Authorization-токен из
+  // реальных вызовов залогиненного юзера и шлёт сюда через postMessage.
 
-  async function autoGrabTokenOnce() {
-    try {
-      const existing = await new Promise(r => chrome.storage.local.get('yamToken', d => r((d && d.yamToken) || '')));
-      if (existing) return; // уже есть, не перезаписываем без необходимости
-    } catch {}
-    // Дать странице время отрендериться и засунуть токен в state.
-    // Background выполнит скан в MAIN world через chrome.scripting (минует CSP).
-    await sleep(1500);
-    try {
-      chrome.runtime.sendMessage({ action: 'grabYamToken' }, (resp) => {
-        if (chrome.runtime.lastError) return;
-        if (resp?.token) console.log('[YMD] grabbed Yandex Music token from', resp.source);
-      });
-    } catch {}
+  function setupTokenListener() {
+    window.addEventListener('message', (e) => {
+      if (e.source !== window) return;
+      const d = e.data;
+      if (!d || d.type !== 'ymd-yam-fetch-token' || !d.token) return;
+      try {
+        chrome.storage.local.get(['yamToken'], (cur) => {
+          if (cur && cur.yamToken === d.token) return;
+          chrome.storage.local.set({
+            yamToken: d.token,
+            yamTokenSource: 'fetch-hook:' + (d.source || ''),
+            yamTokenAt: Date.now(),
+          }, () => {
+            console.log('[YMD] auto-captured Yandex Music token (', d.source, ')');
+          });
+        });
+      } catch {}
+    }, false);
   }
 
-  console.log('[YMD] v3.2 loaded');
+  console.log('[YMD] v3.2.1 loaded');
+  setupTokenListener();
   createFAB();
   start();
-  autoGrabTokenOnce();
 })();

--- a/inject/yam-fetch-hook.js
+++ b/inject/yam-fetch-hook.js
@@ -1,0 +1,89 @@
+// MAIN-world fetch hook для music.yandex.*
+// Перехватывает реальные вызовы страницы к api.music.yandex.net и забирает
+// Authorization-токен. Дальше расширение использует его для скачивания.
+//
+// Manifest подключает этот файл с world: "MAIN" и run_at: "document_start",
+// чтобы хук установился ДО первого fetch страницы.
+
+(function () {
+  if (window.__YMD_FETCH_HOOK__) return;
+  window.__YMD_FETCH_HOOK__ = true;
+
+  const API_HOST = 'api.music.yandex.net';
+  let lastReported = '';
+
+  function reportToken(token, source) {
+    if (!token || token === lastReported) return;
+    if (typeof token !== 'string' || token.length < 20) return;
+    lastReported = token;
+    try {
+      window.postMessage({ type: 'ymd-yam-fetch-token', token, source }, '*');
+    } catch {}
+  }
+
+  function extractFromAuthValue(v) {
+    if (typeof v !== 'string') return '';
+    const m = v.match(/(?:OAuth|Bearer)\s+([A-Za-z0-9_.\-]+)/i);
+    return m ? m[1].trim() : '';
+  }
+
+  function extractFromHeaders(headers) {
+    try {
+      if (!headers) return '';
+      if (headers instanceof Headers) return extractFromAuthValue(headers.get('Authorization') || headers.get('authorization') || '');
+      if (Array.isArray(headers)) {
+        for (const pair of headers) {
+          if (Array.isArray(pair) && pair[0] && pair[0].toLowerCase() === 'authorization') {
+            return extractFromAuthValue(pair[1]);
+          }
+        }
+        return '';
+      }
+      if (typeof headers === 'object') {
+        for (const k in headers) {
+          if (k.toLowerCase() === 'authorization') return extractFromAuthValue(headers[k]);
+        }
+      }
+    } catch {}
+    return '';
+  }
+
+  // 1) window.fetch
+  const origFetch = window.fetch;
+  if (typeof origFetch === 'function') {
+    window.fetch = function (input, init) {
+      try {
+        let url = '';
+        let requestHeaders = null;
+        if (typeof input === 'string') url = input;
+        else if (input && input.url) { url = input.url; requestHeaders = input.headers; }
+        if (url && url.indexOf(API_HOST) !== -1) {
+          const t = extractFromHeaders((init && init.headers) || requestHeaders);
+          if (t) reportToken(t, 'fetch');
+        }
+      } catch {}
+      return origFetch.apply(this, arguments);
+    };
+  }
+
+  // 2) XMLHttpRequest — пишем url в _ymdUrl при open(), забираем токен в setRequestHeader()
+  try {
+    const X = XMLHttpRequest.prototype;
+    const origOpen = X.open;
+    const origSetHeader = X.setRequestHeader;
+    X.open = function (method, url) {
+      try { this._ymdUrl = url; } catch {}
+      return origOpen.apply(this, arguments);
+    };
+    X.setRequestHeader = function (name, value) {
+      try {
+        if (typeof name === 'string' && name.toLowerCase() === 'authorization' &&
+            this._ymdUrl && this._ymdUrl.indexOf(API_HOST) !== -1) {
+          const t = extractFromAuthValue(value);
+          if (t) reportToken(t, 'xhr');
+        }
+      } catch {}
+      return origSetHeader.apply(this, arguments);
+    };
+  } catch {}
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Music Downloader (Я.Музыка / Bandcamp / SoundCloud)",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Скачивайте треки, альбомы и плейлисты с Яндекс Музыки, Bandcamp и SoundCloud — на странице или по ссылке из попапа.",
   "permissions": [
     "activeTab",
@@ -19,6 +19,8 @@
     "*://api.music.yandex.net/*",
     "*://*.storage.mds.yandex.net/*",
     "*://storage.mds.yandex.net/*",
+    "*://*.storage.yandex.net/*",
+    "*://storage.yandex.net/*",
     "*://*.strm.yandex.net/*",
     "*://*.bandcamp.com/*",
     "*://bandcamp.com/*",
@@ -32,6 +34,18 @@
     "service_worker": "background.js"
   },
   "content_scripts": [
+    {
+      "matches": [
+        "*://music.yandex.ru/*",
+        "*://music.yandex.com/*",
+        "*://music.yandex.kz/*",
+        "*://music.yandex.by/*",
+        "*://music.yandex.ua/*"
+      ],
+      "js": ["inject/yam-fetch-hook.js"],
+      "run_at": "document_start",
+      "world": "MAIN"
+    },
     {
       "matches": [
         "*://music.yandex.ru/*",

--- a/services/yandex.js
+++ b/services/yandex.js
@@ -26,6 +26,9 @@
     if (m) return { type: 'album', albumId: m[1] };
     m = p.match(/\/users\/([^/]+)\/playlists\/(\d+)/);
     if (m) return { type: 'playlist', owner: m[1], kinds: m[2] };
+    // Новый формат: /playlists/{uuid}  (например 01a6eb8c-578e-8e47-b4b4-bab9aae9da0b)
+    m = p.match(/\/playlists\/([a-f0-9-]{32,40})/i);
+    if (m) return { type: 'playlist', uuid: m[1] };
     return null;
   }
 
@@ -93,6 +96,12 @@
     return items.map(entry => shapeTrack(entry.track || entry)).filter(t => t.trackId);
   }
 
+  async function fetchPlaylistByUuid(uuid, token) {
+    const pl = await apiGet(`/playlist/${uuid}`, token);
+    const items = pl.tracks || [];
+    return items.map(entry => shapeTrack(entry.track || entry)).filter(t => t.trackId);
+  }
+
   async function fetchSingleTrack(trackId, albumId, token) {
     const list = await apiPost('/tracks', 'track-ids=' + encodeURIComponent(trackId), token);
     const t = (list || [])[0];
@@ -104,7 +113,10 @@
     const token = await getToken();
     if (parsed.type === 'track') return [await fetchSingleTrack(parsed.trackId, parsed.albumId, token)];
     if (parsed.type === 'album') return await fetchAlbumTracks(parsed.albumId, token);
-    if (parsed.type === 'playlist') return await fetchPlaylistTracks(parsed.owner, parsed.kinds, token);
+    if (parsed.type === 'playlist') {
+      if (parsed.uuid) return await fetchPlaylistByUuid(parsed.uuid, token);
+      return await fetchPlaylistTracks(parsed.owner, parsed.kinds, token);
+    }
     return [];
   }
 
@@ -133,12 +145,19 @@
     const pick = (mp3s.length ? mp3s : dlInfo).reduce((a, b) =>
       (b.bitrateInKbps || 0) > (a.bitrateInKbps || 0) ? b : a, dlInfo[0]);
 
+    // storage.mds.yandex.net не отдаёт CORS — fetch через background.
     const sep = pick.downloadInfoUrl.includes('?') ? '&' : '?';
-    const xmlResp = await fetch(pick.downloadInfoUrl + sep + 'format=json', {
-      headers: authHeaders(token),
+    const proxyUrl = pick.downloadInfoUrl + sep + 'format=json';
+    const txt = await new Promise((resolve, reject) => {
+      chrome.runtime.sendMessage(
+        { action: 'corsProxyFetch', url: proxyUrl, headers: {} },
+        (resp) => {
+          if (chrome.runtime.lastError) return reject(new Error(chrome.runtime.lastError.message));
+          if (!resp || !resp.ok) return reject(new Error(resp?.error || 'corsProxyFetch failed'));
+          resolve(resp.body || '');
+        }
+      );
     });
-    if (!xmlResp.ok) throw new Error(`downloadInfoUrl: HTTP ${xmlResp.status}`);
-    const txt = await xmlResp.text();
     let host, path, ts, s;
     try {
       const j = JSON.parse(txt);


### PR DESCRIPTION
## Что исправлено

### #13 — CORS на storage.mds.yandex.net
В v3.2.0 при скачивании трека `services/yandex.js` делал `fetch('https://storage.mds.yandex.net/file-download-info/...')` из content script. storage.mds.yandex.net не отдаёт CORS-хедеры → браузер блокировал запрос. Это всем сломало.

**Фикс:** проксируем этот fetch через background (новый handler `corsProxyFetch`). В background `host_permissions` обходят CORS.

### #14 — Не распознавал UUID-плейлисты
URL вида `https://music.yandex.ru/playlists/01a6eb8c-578e-...` (новый формат публичных плейлистов) парсер игнорировал.

**Фикс:**
- regex для UUID в `parseUrl`
- новый API endpoint: `GET /playlist/{uuid}` (проверил — работает)

### Бонус: автоматический захват токена

В v3.2.0 я искал токен в `window.__STATE_SNAPSHOT__` — это работало через раз, потому что Яндекс хранит токен в неочевидном месте.

**Новый подход:** `inject/yam-fetch-hook.js` — content script с `world: "MAIN"` и `run_at: "document_start"` (нативная поддержка в MV3). Оборачивает `window.fetch` и `XMLHttpRequest`, перехватывает `Authorization` header из реальных вызовов страницы к `api.music.yandex.net`.

Юзер залогинен на music.yandex.ru → любое действие на странице (открыл альбом, нажал play) → токен ловится автоматически.

## Также

- Расширил `webRequest` паттерны: добавил `*.storage.yandex.net` (актуальные mp3 хосты)
- Расширил `host_permissions` для тех же доменов
- Обновил `release.yml` и `ci.yml` чтобы учитывали новую папку `inject/`

## Test plan

- [ ] CI зелёный
- [ ] Скачать релиз v3.2.1, переустановить
- [ ] Зайти на music.yandex.ru, открыть DevTools → консоль → проверить что нет CORS ошибок
- [ ] Кликнуть FAB на текущем треке → должен скачать
- [ ] Из попапа: вставить ссылку на трек/альбом/плейлист (включая UUID-плейлист) → должен скачать
- [ ] Token статус в попапе должен показать "✓ Токен Я.Музыки установлен" с источником "fetch-hook" автоматически

Closes #13
Closes #14