### PR TITLE
Фикс: выбор качества теперь реально работает (был баг с captured URL)

### DIFF
--- a/services/yandex.js
+++ b/services/yandex.js
@@ -180,36 +180,46 @@
   }
 
   async function getAudioUrl(track, ctx) {
-    // 1. Try captured URL (in-page mode — наш фоновый webRequest перехватчик)
+    const quality = await getQualityPref();
+    const token = await getToken();
+
+    // С токеном — ВСЕГДА API-путь, чтобы получить именно выбранное качество.
+    // Captured URL (что плеер уже скачал) — это качество ПЛЕЕРА, не наше.
+    // Если юзер выбрал FLAC, а плеер играл 320 — captured даст 320, не FLAC.
+    if (token) {
+      const dlInfo = await apiGet(`/tracks/${track.trackId}/download-info`, token);
+      if (!Array.isArray(dlInfo) || !dlInfo.length) throw new Error('Я.Музыка не вернула download-info');
+
+      const pick = pickStream(dlInfo, quality);
+      if (!pick) throw new Error('Я.Музыка: подходящий поток не найден');
+      track._codec = pick.codec;
+      track._bitrate = pick.bitrateInKbps;
+      return await resolveDownloadInfoUrl(pick.downloadInfoUrl);
+    }
+
+    // Без токена — фоллбек на captured URL (FAB при заходе на свежую страницу
+    // когда токен ещё не пойман). Качество — какое играл плеер.
     if (ctx?.preferCaptured && ctx.getCapturedAudio) {
       try {
         const captured = await ctx.getCapturedAudio();
-        if (captured) return captured;
+        if (captured) {
+          // Не знаем реальный codec — ставим mp3 как наиболее вероятный.
+          track._codec = track._codec || 'mp3';
+          return captured;
+        }
       } catch { /* fall through */ }
     }
 
-    // 2. API-путь через api.music.yandex.net + OAuth токен
-    const token = await getToken();
-    if (!token) {
-      throw new Error(
-        'Нет токена Я.Музыки. Зайди на music.yandex.ru (расширение попробует поймать ' +
-        'токен автоматически) или вставь вручную в попапе → «Токен».'
-      );
-    }
+    throw new Error(
+      'Нет токена Я.Музыки. Открой music.yandex.ru и залогинься — расширение ' +
+      'поймает токен автоматически. Или вставь вручную в попапе → «Токен Я.Музыки».'
+    );
+  }
 
-    const dlInfo = await apiGet(`/tracks/${track.trackId}/download-info`, token);
-    if (!Array.isArray(dlInfo) || !dlInfo.length) throw new Error('Я.Музыка не вернула download-info');
-
-    const quality = await getQualityPref();
-    const pick = pickStream(dlInfo, quality);
-    if (!pick) throw new Error('Я.Музыка: подходящий поток не найден');
-    // Запоминаем codec на треке, чтоб getFilename выбрал правильное расширение
-    track._codec = pick.codec;
-    track._bitrate = pick.bitrateInKbps;
-
+  async function resolveDownloadInfoUrl(downloadInfoUrl) {
     // storage.mds.yandex.net не отдаёт CORS — fetch через background.
-    const sep = pick.downloadInfoUrl.includes('?') ? '&' : '?';
-    const proxyUrl = pick.downloadInfoUrl + sep + 'format=json';
+    const sep = downloadInfoUrl.includes('?') ? '&' : '?';
+    const proxyUrl = downloadInfoUrl + sep + 'format=json';
     const txt = await new Promise((resolve, reject) => {
       chrome.runtime.sendMessage(
         { action: 'corsProxyFetch', url: proxyUrl, headers: {} },


### PR DESCRIPTION
## Что не так было

Юзер выбирает FLAC в попапе → жмёт FAB на текущем треке → получает **MP3 320** или какое там качество в плеере, **не FLAC**.

### Корень бага

`services/yandex.js#getAudioUrl` в v3.3.0 имел такую логику:

```js
// 1. Try captured URL первым делом
if (ctx?.preferCaptured && ctx.getCapturedAudio) {
  const captured = await ctx.getCapturedAudio();
  if (captured) return captured;   // ← возврат тут, до выбора качества
}
// 2. API path с pickStream(quality) — никогда не доходим если FAB
```

"Captured URL" — это URL который браузер **уже скачал** при воспроизведении трека. Качество = качество плеера юзера, не наше. Если он играет в 320, captured URL → 320, даже если в попапе выбран FLAC.

## Фикс

- **Есть токен → ВСЕГДА API-путь** с `pickStream(dlInfo, quality)`. Получаем именно выбранное качество.
- **Нет токена → fallback на captured URL** (редкий случай, до того как fetch-hook поймал токен).

Бонусом: вынес `resolveDownloadInfoUrl` в отдельную функцию (был дубликат логики).

## Test plan

- [ ] CI зелёный
- [ ] С Я.Плюсом и выбранным «FLAC» — FAB скачивает .flac (независимо от того в каком качестве плеер играл)
- [ ] С выбранным «MP3 192» — скачивается .mp3 ~7 МБ
- [ ] С «Авто» — FLAC если есть, MP3 320 если нет

⚠ **Не релизить пока не скажу.**