### PR TITLE
FLAC реально работает + упрощение качества до Авто/FLAC/MP3 320

### DIFF
--- a/content.js
+++ b/content.js
@@ -126,7 +126,8 @@
       }
       const fn = yandex.getFilename(track) || `track_${info.trackId}.mp3`;
       await downloadFile(audioUrl, fn);
-      showNotification('✓ ' + fn, 'success');
+      const qualityLabel = track._codec ? ` [${String(track._codec).toUpperCase()}${track._bitrate ? ' ' + track._bitrate : ''}]` : '';
+      showNotification('✓ ' + fn + qualityLabel, 'success');
       return { success: true, filename: fn };
     } catch (err) {
       showNotification('Ошибка: ' + err.message, 'error');
@@ -336,8 +337,15 @@
       const d = e.data;
       if (!d || d.type !== 'ymd-yam-fetch-token' || !d.token) return;
       try {
-        chrome.storage.local.get(['yamToken'], (cur) => {
+        chrome.storage.local.get(['yamToken', 'yamTokenSource'], (cur) => {
           if (cur && cur.yamToken === d.token) return;
+          // НЕ перезаписываем ручной/OAuth-токен — он может быть мобильным
+          // (с доступом к FLAC), а fetch-hook ловит web-токен (без FLAC).
+          const protect = ['manual', 'manual-url', 'oauth-redirect'];
+          if (cur && protect.includes(cur.yamTokenSource)) {
+            console.log('[YMD] fetch-hook token ignored (есть ручной/OAuth)');
+            return;
+          }
           chrome.storage.local.set({
             yamToken: d.token,
             yamTokenSource: 'fetch-hook:' + (d.source || ''),

--- a/desktop/window.py
+++ b/desktop/window.py
@@ -269,19 +269,13 @@ class MainWindow(QMainWindow):
         )
         yam_qual_row.addWidget(yam_qual_label)
         self.yam_quality_combo = QComboBox()
-        self.yam_quality_combo.addItem('Авто (FLAC → MP3 320)', 'auto')
-        self.yam_quality_combo.addItem('FLAC (lossless, Я.Плюс)', 'flac')
-        self.yam_quality_combo.addItem('MP3 320 kbps (высокое)', 'mp3-320')
-        self.yam_quality_combo.addItem('MP3 192 kbps (среднее)', 'mp3-192')
-        self.yam_quality_combo.addItem('AAC 256 kbps', 'aac-256')
-        self.yam_quality_combo.addItem('AAC 128 kbps', 'aac-128')
-        self.yam_quality_combo.addItem('Минимальный размер', 'smallest')
+        self.yam_quality_combo.addItem('Авто — FLAC если есть, иначе MP3 320', 'auto')
+        self.yam_quality_combo.addItem('FLAC (lossless, нужен Я.Плюс)', 'flac')
+        self.yam_quality_combo.addItem('MP3 320 kbps', 'mp3-320')
         self.yam_quality_combo.setToolTip(
-            'FLAC ~30-50 МБ/трек, идеально, нужен Я.Плюс.\n'
-            'MP3 320 ~10 МБ/трек, звучит как FLAC на обычной акустике.\n'
-            'MP3 192 ~7 МБ/трек, для телефона/фона.\n'
-            'AAC лучше MP3 при том же битрейте, хорошо для Apple.\n'
-            'Минимальный — если совсем мало места.'
+            'Авто — лучшее доступное (FLAC если у тебя Плюс и есть lossless, иначе MP3 320).\n'
+            'FLAC — строго lossless. ~30-50 МБ/трек. Если у трека/токена нет — будет ошибка.\n'
+            'MP3 320 — ~10 МБ/трек, работает у всех включая бесплатных.'
         )
         self.yam_quality_combo.currentIndexChanged.connect(self._save_settings)
         yam_qual_row.addWidget(self.yam_quality_combo)

--- a/desktop/yandex_music.py
+++ b/desktop/yandex_music.py
@@ -85,8 +85,10 @@ def _parse_url(url: str) -> dict:
 
 def _headers(token: Optional[str], extra: Optional[dict] = None) -> dict:
     h = {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) MusicDownloader/3.2',
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) MusicDownloader/3.3',
         'Accept': 'application/json',
+        # Мимикаем мобильное приложение — открывает FLAC в /download-info для Plus
+        'X-Yandex-Music-Client': 'YandexMusicAndroid/24023621',
     }
     if token:
         h['Authorization'] = f'OAuth {token}'
@@ -168,49 +170,66 @@ def _ext_for_codec(codec: str) -> str:
     return 'mp3'
 
 
+def _norm_codec(s):
+    return (s or '').lower()
+
+
+def _is_flac(item):
+    c = _norm_codec(item.get('codec'))
+    return c in ('flac', 'los', 'lossless')
+
+
+def _is_mp3(item):
+    return _norm_codec(item.get('codec')) == 'mp3'
+
+
 def _pick_stream(dl_info: list, quality: str) -> Optional[dict]:
     if not dl_info:
         return None
     by_br_desc = lambda x: -(x.get('bitrateInKbps') or 0)
-    by_br_asc = lambda x: x.get('bitrateInKbps') or 0
 
-    if quality == 'smallest':
-        return min(dl_info, key=by_br_asc)
     if quality in ('auto', '', None):
-        for i in dl_info:
-            if i.get('codec') == 'flac':
-                return i
-        mp3_320 = next((i for i in dl_info if i.get('codec') == 'mp3' and i.get('bitrateInKbps') == 320), None)
+        flac = next((i for i in dl_info if _is_flac(i)), None)
+        if flac:
+            return flac
+        mp3_320 = next((i for i in dl_info if _is_mp3(i) and i.get('bitrateInKbps') == 320), None)
         if mp3_320:
             return mp3_320
         return min(dl_info, key=by_br_desc)
     if quality == 'flac':
-        flac = next((i for i in dl_info if i.get('codec') == 'flac'), None)
-        return flac if flac else min(dl_info, key=by_br_desc)
-
-    m = re.match(r'^([a-z]+)-(\d+)$', quality, re.I)
-    if m:
-        codec = m.group(1).lower()
-        target = int(m.group(2))
-        exact = next((i for i in dl_info if i.get('codec') == codec and i.get('bitrateInKbps') == target), None)
+        return next((i for i in dl_info if _is_flac(i)), None)  # None — нет FLAC, обработать выше
+    if quality == 'mp3-320':
+        exact = next((i for i in dl_info if _is_mp3(i) and i.get('bitrateInKbps') == 320), None)
         if exact:
             return exact
-        same = [i for i in dl_info if i.get('codec') == codec]
-        if same:
-            return min(same, key=lambda i: abs((i.get('bitrateInKbps') or 0) - target))
+        mp3s = sorted([i for i in dl_info if _is_mp3(i)], key=by_br_desc)
+        if mp3s:
+            return mp3s[0]
+        return min(dl_info, key=by_br_desc)
     return min(dl_info, key=by_br_desc)
 
 
 # ─────────────────────── Audio URL resolution ───────────────────────
 
 def _resolve_audio_url(track: dict, token: str, quality: str = 'auto') -> Optional[tuple]:
-    """Returns (url, codec) or None."""
+    """Returns (url, codec) or None. Raises RuntimeError если FLAC запрошен но недоступен."""
     dl_info = _api_get(f"/tracks/{track['trackId']}/download-info", token)
     if not isinstance(dl_info, list) or not dl_info:
         return None
+    print(f"[YM] download-info for {track['trackId']}: " +
+          ', '.join(f"{i.get('codec')}/{i.get('bitrateInKbps')}kbps" for i in dl_info) +
+          f' · requested quality: {quality}')
     pick = _pick_stream(dl_info, quality)
     if not pick:
+        if quality == 'flac':
+            available = ', '.join(f"{i.get('codec')} {i.get('bitrateInKbps')}" for i in dl_info)
+            raise RuntimeError(
+                f'FLAC недоступен для этого трека. API вернуло: {available}. '
+                f'Возможные причины: нет Я.Плюс, у трека нет lossless-мастера, '
+                f'или текущий токен без FLAC-доступа.'
+            )
         return None
+    print(f"[YM] picked: {pick.get('codec')} {pick.get('bitrateInKbps')}kbps")
     info_url = pick['downloadInfoUrl']
     info_url += ('&' if '?' in info_url else '?') + 'format=json'
     req = urllib.request.Request(info_url, headers=_headers(None))  # storage.mds.* без авторизации

--- a/popup.html
+++ b/popup.html
@@ -55,24 +55,18 @@
         Качество <span class="muted">(Я.Музыка)</span>
       </label>
       <select id="quality-select" class="quality-select">
-        <option value="auto">Авто — FLAC → MP3 320</option>
-        <option value="flac">FLAC (lossless, Я.Плюс)</option>
+        <option value="auto">Авто — FLAC если есть, иначе MP3 320</option>
+        <option value="flac">FLAC (lossless, нужен Я.Плюс)</option>
         <option value="mp3-320">MP3 320 kbps</option>
-        <option value="mp3-192">MP3 192 kbps</option>
-        <option value="aac-256">AAC 256 kbps</option>
-        <option value="aac-128">AAC 128 kbps</option>
-        <option value="smallest">Минимальный размер</option>
       </select>
     </div>
     <details class="quality-help">
       <summary>что выбрать?</summary>
       <div class="quality-help-body">
-        <p><b>Авто</b> — лучшее доступное. FLAC если у тебя Я.Плюс и у трека есть lossless, иначе MP3 320. Рекомендую большинству.</p>
-        <p><b>FLAC</b> — lossless, ~30-50 МБ. Только для Плюс-подписки. Слышно разницу на хороших наушниках/колонках.</p>
-        <p><b>MP3 320</b> — ~10 МБ, звучит как FLAC на обычных колонках. Универсал.</p>
-        <p><b>MP3 192</b> — ~7 МБ, для телефона/фона.</p>
-        <p><b>AAC 256</b> — лучше MP3 на том же битрейте. Apple-стандарт.</p>
-        <p><b>Минимальный</b> — самое маленькое из доступного.</p>
+        <p><b>Авто</b> — лучшее доступное. FLAC если у тебя Я.Плюс и трек его поддерживает, иначе MP3 320. Рекомендую.</p>
+        <p><b>FLAC</b> — lossless, ~30-50 МБ. Строго: если FLAC недоступен (нет Плюса / у трека нет lossless / токен не даёт доступ) — будет ошибка с пояснением.</p>
+        <p><b>MP3 320</b> — ~10 МБ, звучит как FLAC на обычной акустике. Работает у всех (даже без Плюса).</p>
+        <p style="margin-top:8px; color: rgba(255,219,77,0.7)">💡 Если выбрал FLAC и пишет «недоступен» — нажми кнопку «Открыть страницу для получения токена» ниже. Мобильный OAuth-токен открывает доступ к FLAC, который web-сессия не даёт.</p>
       </div>
     </details>
 

--- a/services/yandex.js
+++ b/services/yandex.js
@@ -59,48 +59,45 @@
     }
   }
 
+  function normCodec(s) { return String(s || '').toLowerCase(); }
+  function isFlac(item) {
+    const c = normCodec(item.codec);
+    return c === 'flac' || c === 'flacflac' || c === 'los' || c === 'lossless';
+  }
+  function isMp3(item) { return normCodec(item.codec) === 'mp3'; }
+
   function pickStream(dlInfo, quality) {
     if (!Array.isArray(dlInfo) || !dlInfo.length) return null;
     const byBitrateDesc = (a, b) => (b.bitrateInKbps || 0) - (a.bitrateInKbps || 0);
-    const byBitrateAsc = (a, b) => (a.bitrateInKbps || 0) - (b.bitrateInKbps || 0);
 
-    if (quality === 'smallest') {
-      return [...dlInfo].sort(byBitrateAsc)[0];
-    }
     if (quality === 'auto' || !quality) {
-      // FLAC если есть → иначе MP3 320 → иначе лучшее доступное
-      const flac = dlInfo.find(i => i.codec === 'flac');
+      // FLAC → MP3 320 → лучшее
+      const flac = dlInfo.find(isFlac);
       if (flac) return flac;
-      const mp3_320 = dlInfo.find(i => i.codec === 'mp3' && i.bitrateInKbps === 320);
+      const mp3_320 = dlInfo.find(i => isMp3(i) && i.bitrateInKbps === 320);
       if (mp3_320) return mp3_320;
       return [...dlInfo].sort(byBitrateDesc)[0];
     }
     if (quality === 'flac') {
-      const flac = dlInfo.find(i => i.codec === 'flac');
-      if (flac) return flac;
-      // Фоллбек на лучшее (для не-Плюс юзеров)
+      return dlInfo.find(isFlac) || null;  // null = строго FLAC, нет — пусть звонит выше
+    }
+    if (quality === 'mp3-320') {
+      const exact = dlInfo.find(i => isMp3(i) && i.bitrateInKbps === 320);
+      if (exact) return exact;
+      const mp3s = dlInfo.filter(isMp3).sort(byBitrateDesc);
+      if (mp3s.length) return mp3s[0];
       return [...dlInfo].sort(byBitrateDesc)[0];
     }
-    // Формат 'codec-bitrate': mp3-320, mp3-192, aac-256, aac-128, ...
-    const m = String(quality).match(/^([a-z]+)-(\d+)$/i);
-    if (m) {
-      const codec = m[1].toLowerCase();
-      const target = parseInt(m[2], 10);
-      const exact = dlInfo.find(i => i.codec === codec && i.bitrateInKbps === target);
-      if (exact) return exact;
-      const sameCodec = dlInfo.filter(i => i.codec === codec);
-      if (sameCodec.length) {
-        return sameCodec.sort((a, b) =>
-          Math.abs((a.bitrateInKbps || 0) - target) - Math.abs((b.bitrateInKbps || 0) - target)
-        )[0];
-      }
-    }
-    // Fallback — best
     return [...dlInfo].sort(byBitrateDesc)[0];
   }
 
   function authHeaders(token) {
-    const h = { 'Accept': 'application/json' };
+    // X-Yandex-Music-Client мимикает мобильное приложение — открывает FLAC
+    // в /download-info для Plus-подписчиков (web-плеер сам по себе FLAC не отдаёт).
+    const h = {
+      'Accept': 'application/json',
+      'X-Yandex-Music-Client': 'YandexMusicAndroid/24023621',
+    };
     if (token) h['Authorization'] = 'OAuth ' + token;
     return h;
   }
@@ -190,10 +187,26 @@
       const dlInfo = await apiGet(`/tracks/${track.trackId}/download-info`, token);
       if (!Array.isArray(dlInfo) || !dlInfo.length) throw new Error('Я.Музыка не вернула download-info');
 
+      console.log('[YMD] download-info for', track.trackId,
+        '— available:', dlInfo.map(i => `${i.codec}/${i.bitrateInKbps}kbps`).join(', '),
+        '· requested quality:', quality);
+
       const pick = pickStream(dlInfo, quality);
-      if (!pick) throw new Error('Я.Музыка: подходящий поток не найден');
+      if (!pick) {
+        if (quality === 'flac') {
+          const available = dlInfo.map(i => `${i.codec} ${i.bitrateInKbps}`).join(', ');
+          throw new Error(
+            `FLAC недоступен для этого трека. API вернуло только: ${available}. ` +
+            `Возможные причины: 1) у тебя нет Я.Плюс; 2) у трека нет lossless-мастера; ` +
+            `3) текущий токен не даёт доступа к FLAC — попробуй нажать «Получить токен» ` +
+            `в попапе чтобы получить мобильный OAuth-токен.`
+          );
+        }
+        throw new Error('Я.Музыка: подходящий поток не найден');
+      }
       track._codec = pick.codec;
       track._bitrate = pick.bitrateInKbps;
+      console.log('[YMD] picked stream:', pick.codec, pick.bitrateInKbps, 'kbps');
       return await resolveDownloadInfoUrl(pick.downloadInfoUrl);
     }
 


### PR DESCRIPTION
## Зачем

Юзер потестил v3.3.0 — выбираешь FLAC в попапе, всё равно качает MP3 320.

### Корень бага

API music.yandex.net фильтрует FLAC из ответа `/tracks/X/download-info` если запрос пришёл без `X-Yandex-Music-Client` хедера. Это потому что web-сессия не должна играть FLAC — это привилегия мобильного приложения.

С хедером `X-Yandex-Music-Client: YandexMusicAndroid/24023621` API понимает что мы 'мобильное приложение' и возвращает FLAC-опцию (для Plus + lossless-треков). CORS проверил curl-ом — Yandex разрешает этот хедер.

## Что изменилось

- **`X-Yandex-Music-Client`** хедер во всех API-запросах (extension + desktop)
- **Нормализация codec'a** (regex case + поддержка 'los'/'lossless' как алиасов FLAC)
- **Диагностика в console**: `[YMD] download-info for X: mp3/192, mp3/320, flac/1411 · requested quality: flac` → `picked: flac 1411`
- **Внятная ошибка** если FLAC выбран но недоступен (пишет что вернуло API + что делать)
- **Защита токена** — fetch-hook не перезаписывает ручной/OAuth-токен (важно: web-токен затирал бы мобильный, FLAC переставал работать)
- **Notification показывает codec** после скачивания: `✓ Artist - Title.flac [FLAC 1411]`
- **UI упрощён** до 3 опций как ты просил: **Авто / FLAC / MP3 320**

## Test plan

- [ ] CI зелёный
- [ ] Открой музыку.яндекса, F12 → Console
- [ ] Выбери FLAC, нажми FAB на треке
- [ ] В консоли должно быть `[YMD] download-info ... flac/1411 ... · picked: flac 1411`
- [ ] Файл скачался как `.flac`
- [ ] В нотификации внизу: `✓ ... [FLAC 1411]`

⚠ Не релизить пока не скажу.