### PR TITLE
FLAC через новый /get-file-info с HMAC-подписью

### DIFF
--- a/desktop/yandex_music.py
+++ b/desktop/yandex_music.py
@@ -19,8 +19,10 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
 import re
+import time
 import urllib.parse
 import urllib.request
 from pathlib import Path
@@ -28,6 +30,7 @@ from typing import Callable, Optional
 
 API_BASE = 'https://api.music.yandex.net'
 SIGN_SALT = 'XGRlBW9FXlekgbPrRHuSiA'
+V2_HMAC_KEY = b'p93jhgh689SBReK6ghtw62'
 OAUTH_URL = (
     'https://oauth.yandex.ru/authorize?response_type=token'
     '&client_id=23cabbbdc6cd418abb4b39c32c41195d'
@@ -211,25 +214,72 @@ def _pick_stream(dl_info: list, quality: str) -> Optional[dict]:
 
 # ─────────────────────── Audio URL resolution ───────────────────────
 
+def _get_file_info_v2(track_id: str, token: str, quality: str = 'lossless') -> Optional[dict]:
+    """Новый эндпоинт /get-file-info с HMAC-подписью. Даёт прямой URL для FLAC
+    при наличии мобильного OAuth-токена. Возвращает result-словарь или None если
+    эндпоинт отказал."""
+    ts = int(time.time())
+    codecs = 'flac,aac,mp3'
+    transports = 'raw'
+    sign = hmac.new(V2_HMAC_KEY, f'{ts}{track_id}{codecs}{transports}'.encode(), hashlib.sha256).hexdigest()
+    url = (f'{API_BASE}/get-file-info?ts={ts}&trackId={track_id}'
+           f'&quality={quality}&codecs={codecs}&transports={transports}&sign={sign}')
+    try:
+        req = urllib.request.Request(url, headers=_headers(token))
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read().decode('utf-8'))
+        return data.get('result', data)
+    except urllib.error.HTTPError as e:
+        body = ''
+        try:
+            body = e.read().decode('utf-8', errors='replace')[:200]
+        except Exception:
+            pass
+        raise RuntimeError(f'/get-file-info {e.code}: {body}')
+
+
 def _resolve_audio_url(track: dict, token: str, quality: str = 'auto') -> Optional[tuple]:
     """Returns (url, codec) or None. Raises RuntimeError если FLAC запрошен но недоступен."""
+    # V2 для FLAC и Auto
+    if quality in ('flac', 'auto', '', None):
+        try:
+            v2 = _get_file_info_v2(track['trackId'], token, 'lossless')
+            v2_codec = _norm_codec(v2.get('codec') if v2 else '')
+            v2_urls = v2.get('urls') if v2 else None
+            v2_url = v2_urls[0] if v2_urls else v2.get('downloadInfoUrl') if v2 else None
+            if v2_url and v2_codec:
+                if quality != 'flac' or v2_codec == 'flac':
+                    print(f"[YM] V2: {v2_codec} {v2.get('bitrate')}kbps · direct URL")
+                    return (v2_url, v2_codec)
+                print(f"[YM] V2 вернул не-FLAC ({v2_codec}), fallback на V1")
+        except Exception as e:
+            print(f"[YM] V2 failed: {e}")
+            if quality == 'flac':
+                msg = str(e)
+                is_auth = '403' in msg or 'not-allowed' in msg
+                raise RuntimeError(
+                    'FLAC недоступен: текущий токен не имеет доступа к lossless. '
+                    'Получи мобильный OAuth-токен через кнопку «Получить» — он даёт нужный scope.'
+                    if is_auth else f'FLAC недоступен: {msg}'
+                )
+            # Для auto — fallback на V1
+
+    # V1 — /download-info
     dl_info = _api_get(f"/tracks/{track['trackId']}/download-info", token)
     if not isinstance(dl_info, list) or not dl_info:
         return None
-    print(f"[YM] download-info for {track['trackId']}: " +
+    print(f"[YM] V1 download-info: " +
           ', '.join(f"{i.get('codec')}/{i.get('bitrateInKbps')}kbps" for i in dl_info) +
-          f' · requested quality: {quality}')
+          f' · requested: {quality}')
     pick = _pick_stream(dl_info, quality)
     if not pick:
         if quality == 'flac':
             available = ', '.join(f"{i.get('codec')} {i.get('bitrateInKbps')}" for i in dl_info)
             raise RuntimeError(
-                f'FLAC недоступен для этого трека. API вернуло: {available}. '
-                f'Возможные причины: нет Я.Плюс, у трека нет lossless-мастера, '
-                f'или текущий токен без FLAC-доступа.'
+                f'FLAC недоступен. API вернуло: {available}. Получи мобильный OAuth-токен.'
             )
         return None
-    print(f"[YM] picked: {pick.get('codec')} {pick.get('bitrateInKbps')}kbps")
+    print(f"[YM] V1 picked: {pick.get('codec')} {pick.get('bitrateInKbps')}kbps")
     info_url = pick['downloadInfoUrl']
     info_url += ('&' if '?' in info_url else '?') + 'format=json'
     req = urllib.request.Request(info_url, headers=_headers(None))  # storage.mds.* без авторизации

--- a/services/yandex.js
+++ b/services/yandex.js
@@ -59,6 +59,44 @@
     }
   }
 
+  // HMAC-ключ для V2 (/get-file-info) — из публичных yandex-music API реверсов
+  const V2_HMAC_KEY = 'p93jhgh689SBReK6ghtw62';
+
+  async function hmacSha256Hex(keyStr, msgStr) {
+    const enc = new TextEncoder();
+    const key = await crypto.subtle.importKey(
+      'raw', enc.encode(keyStr),
+      { name: 'HMAC', hash: 'SHA-256' },
+      false, ['sign']
+    );
+    const sig = await crypto.subtle.sign('HMAC', key, enc.encode(msgStr));
+    return Array.from(new Uint8Array(sig)).map(b => b.toString(16).padStart(2, '0')).join('');
+  }
+
+  async function getFileInfoV2(trackId, token, quality) {
+    // Новый эндпоинт api.music.yandex.net/get-file-info с HMAC-подписью.
+    // Возвращает прямой URL (без MD5-sign дополнительного), и поддерживает FLAC
+    // для мобильных OAuth-токенов (web-токен → 403 not-allowed).
+    const ts = Math.floor(Date.now() / 1000);
+    const codecs = 'flac,aac,mp3';
+    const transports = 'raw';
+    const sign = await hmacSha256Hex(V2_HMAC_KEY, `${ts}${trackId}${codecs}${transports}`);
+    const url = `${API_BASE}/get-file-info?ts=${ts}&trackId=${trackId}` +
+      `&quality=${encodeURIComponent(quality)}` +
+      `&codecs=${encodeURIComponent(codecs)}` +
+      `&transports=${encodeURIComponent(transports)}` +
+      `&sign=${sign}`;
+    const resp = await fetch(url, { headers: authHeaders(token) });
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => '');
+      let name = '';
+      try { name = JSON.parse(text).result?.name || ''; } catch {}
+      throw new Error(`/get-file-info ${resp.status} ${name || text.slice(0, 100)}`);
+    }
+    const data = await resp.json();
+    return data.result || data;
+  }
+
   function normCodec(s) { return String(s || '').toLowerCase(); }
   function isFlac(item) {
     const c = normCodec(item.codec);
@@ -180,30 +218,54 @@
     const quality = await getQualityPref();
     const token = await getToken();
 
-    // С токеном — ВСЕГДА API-путь, чтобы получить именно выбранное качество.
-    // Captured URL (что плеер уже скачал) — это качество ПЛЕЕРА, не наше.
-    // Если юзер выбрал FLAC, а плеер играл 320 — captured даст 320, не FLAC.
     if (token) {
+      // Для FLAC и Auto — сначала пробуем V2 эндпоинт /get-file-info (даёт прямой
+      // URL для FLAC). Если токен мобильный (OAuth client_id Яндекс.Музыки) —
+      // получим lossless. Если web-токен — будет 403 not-allowed, фоллбек на V1.
+      if (quality === 'flac' || quality === 'auto' || !quality) {
+        try {
+          const v2 = await getFileInfoV2(track.trackId, token, 'lossless');
+          const v2url = v2?.urls?.[0] || v2?.downloadInfoUrl;
+          const v2codec = normCodec(v2?.codec);
+          if (v2url && v2codec) {
+            // Если запросили строго FLAC и получили его — отдаём
+            // Если Auto — отдаём что есть (это лучшее что V2 выдал)
+            if (quality !== 'flac' || v2codec === 'flac') {
+              track._codec = v2.codec;
+              track._bitrate = v2.bitrate;
+              console.log('[YMD] V2 endpoint:', v2.codec, v2.bitrate, 'kbps · direct URL');
+              return v2url;
+            }
+            console.log('[YMD] V2 вернул не-FLAC (' + v2.codec + '), хотя запросили FLAC. Fallback на V1.');
+          }
+        } catch (err) {
+          console.warn('[YMD] V2 endpoint failed:', err.message);
+          if (quality === 'flac') {
+            // Строгий FLAC — без V2 не получится. Внятная ошибка.
+            const isAuth = /403|not-allowed/i.test(err.message);
+            throw new Error(
+              isAuth
+                ? 'FLAC недоступен: текущий токен не имеет доступа к lossless. ' +
+                  'Нажми в попапе «Открыть страницу для получения токена» — это ' +
+                  'мобильный OAuth-флоу, он даёт нужный scope для FLAC. ' +
+                  '(Авто-захваченный токен с music.yandex.ru — это web-сессия, у неё нет FLAC.)'
+                : 'FLAC недоступен: ' + err.message
+            );
+          }
+          // Для Auto — продолжаем в V1 path
+        }
+      }
+
+      // V1 path — /tracks/X/download-info (для MP3 и как fallback)
       const dlInfo = await apiGet(`/tracks/${track.trackId}/download-info`, token);
       if (!Array.isArray(dlInfo) || !dlInfo.length) throw new Error('Я.Музыка не вернула download-info');
 
-      console.log('[YMD] download-info for', track.trackId,
+      console.log('[YMD] V1 download-info for', track.trackId,
         '— available:', dlInfo.map(i => `${i.codec}/${i.bitrateInKbps}kbps`).join(', '),
         '· requested quality:', quality);
 
       const pick = pickStream(dlInfo, quality);
-      if (!pick) {
-        if (quality === 'flac') {
-          const available = dlInfo.map(i => `${i.codec} ${i.bitrateInKbps}`).join(', ');
-          throw new Error(
-            `FLAC недоступен для этого трека. API вернуло только: ${available}. ` +
-            `Возможные причины: 1) у тебя нет Я.Плюс; 2) у трека нет lossless-мастера; ` +
-            `3) текущий токен не даёт доступа к FLAC — попробуй нажать «Получить токен» ` +
-            `в попапе чтобы получить мобильный OAuth-токен.`
-          );
-        }
-        throw new Error('Я.Музыка: подходящий поток не найден');
-      }
+      if (!pick) throw new Error('Я.Музыка: подходящий поток не найден');
       track._codec = pick.codec;
       track._bitrate = pick.bitrateInKbps;
       console.log('[YMD] picked stream:', pick.codec, pick.bitrateInKbps, 'kbps');


### PR DESCRIPTION
## Проблема

Юзер потестил v3.3.0 в DevTools — API на текущем токене **всегда** возвращает только `mp3/192kbps, mp3/320kbps` через `/tracks/X/download-info`, даже с `X-Yandex-Music-Client` хедером. FLAC просто отсутствует в ответе.

## Решение

Новый эндпоинт **`/get-file-info`** с HMAC-SHA256 подписью — стандартный путь который используют open-source библиотеки (`yandex-music-api` и т.п.). Проверил curl-ом:
- Без подписи → `400 missing-query-parameter`
- С подписью + анонимно → `403 not-allowed` (значит формат подписи правильный, нужна авторизация)
- CORS allowed для music.yandex.ru

HMAC-ключ `p93jhgh689SBReK6ghtw62` (публично известный, обратный инжиниринг Android-приложения Яндекс.Музыки).

## Что меняется

- **`services/yandex.js`**: `hmacSha256Hex` через Web Crypto API, `getFileInfoV2` с подписью
- В `getAudioUrl` для FLAC/Auto — сначала V2, fallback на V1
- 403 на V2 = клиентский токен (web), не имеет FLAC scope. Внятная ошибка с инструкцией: «нажми Получить токен для мобильного OAuth»
- **`desktop/yandex_music.py`**: симметрично

## Поведение

| Сценарий | Результат |
|---|---|
| Авто-захваченный web-токен + 'Auto' | V2 → 403, V1 → MP3 320 (как было) |
| Авто-захваченный web-токен + 'FLAC' | V2 → 403, ошибка: «получи мобильный OAuth-токен» |
| Мобильный OAuth-токен + 'FLAC' | V2 → FLAC прямой URL ✓ |
| Мобильный OAuth-токен + 'Auto' | V2 → FLAC (если Plus + lossless у трека) ✓ |

⚠ Не релизить пока юзер не подтвердит что FLAC реально работает.