### PR TITLE
FLAC через encrypted V2 endpoint + AES-CTR расшифровка

### DIFF
--- a/background.js
+++ b/background.js
@@ -100,6 +100,39 @@ function getSaveAs() {
   return new Promise(resolve => chrome.storage.local.get('saveAs', d => resolve(!!d.saveAs)));
 }
 
+// Скачать зашифрованный поток (transport=encraw из /get-file-info Я.Музыки),
+// расшифровать AES-CTR с zero-nonce и hex-ключом, сохранить через blob URL.
+async function decryptAndDownload(url, key, filename, saveAs) {
+  const r = await fetch(url, { credentials: 'omit' });
+  if (!r.ok) throw new Error(`fetch encrypted ${r.status}`);
+  const encrypted = new Uint8Array(await r.arrayBuffer());
+
+  // hex key → Uint8Array
+  const keyBytes = new Uint8Array(key.length / 2);
+  for (let i = 0; i < keyBytes.length; i++) {
+    keyBytes[i] = parseInt(key.substr(i * 2, 2), 16);
+  }
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw', keyBytes, { name: 'AES-CTR' }, false, ['decrypt']
+  );
+  // 16 байт всего: 12 байт nonce (нули) + 4 байта counter. length=32 bits.
+  // Эквивалент pycryptodome AES.new(key, MODE_CTR, nonce=bytes(12)).
+  const counter = new Uint8Array(16);
+  const decrypted = await crypto.subtle.decrypt(
+    { name: 'AES-CTR', counter, length: 32 }, cryptoKey, encrypted
+  );
+
+  const blob = new Blob([decrypted]);
+  const blobUrl = URL.createObjectURL(blob);
+  return new Promise(resolve => {
+    chrome.downloads.download({ url: blobUrl, filename, saveAs: !!saveAs }, (id) => {
+      setTimeout(() => { try { URL.revokeObjectURL(blobUrl); } catch {} }, 30000);
+      if (chrome.runtime.lastError) resolve({ ok: false, error: chrome.runtime.lastError.message });
+      else resolve({ ok: true, downloadId: id, size: decrypted.byteLength });
+    });
+  });
+}
+
 // ═══════════════════════════════════════
 // PASTE-LINK FLOW (cross-service)
 // ═══════════════════════════════════════
@@ -140,11 +173,20 @@ async function downloadByUrl(rawUrl) {
     const labelTitle = (t.artist && t.title) ? `${t.artist} - ${t.title}` : (t.title || `track ${i + 1}`);
     pushProgress({ status: 'progress', current: i + 1, total: tracks.length, title: labelTitle });
     try {
-      const audioUrl = await service.getAudioUrl(t, {});
-      if (!audioUrl) throw new Error('audio URL пустой');
+      const result = await service.getAudioUrl(t, {});
+      if (!result) throw new Error('audio URL пустой');
       const filename = service.getFilename(t) || `track.mp3`;
       const fullName = isBatch ? `${folder}/${filename}` : filename;
-      const res = await chromeDownload(audioUrl, fullName, saveAs && !isBatch);
+
+      let res;
+      if (typeof result === 'object' && result.encrypted && result.key) {
+        // V2 Я.Музыки: зашифрованный поток, нужно расшифровать
+        res = await decryptAndDownload(result.url, result.key, fullName, saveAs && !isBatch);
+        res = { success: res.ok, error: res.error };
+      } else {
+        const audioUrl = typeof result === 'string' ? result : result.url;
+        res = await chromeDownload(audioUrl, fullName, saveAs && !isBatch);
+      }
       if (res.success) downloaded++;
       else console.warn('[YMD] download failed:', res.error);
     } catch (err) {
@@ -210,6 +252,13 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         else sendResponse(resp || { success: false });
       });
     });
+    return true;
+  }
+
+  if (message.action === 'downloadEncrypted') {
+    decryptAndDownload(message.url, message.key, message.filename, !!message.saveAs)
+      .then(res => sendResponse(res))
+      .catch(err => sendResponse({ ok: false, error: err.message || String(err) }));
     return true;
   }
 

--- a/background.js
+++ b/background.js
@@ -101,13 +101,17 @@ function getSaveAs() {
 }
 
 // Скачать зашифрованный поток (transport=encraw из /get-file-info Я.Музыки),
-// расшифровать AES-CTR с zero-nonce и hex-ключом, сохранить через blob URL.
+// расшифровать AES-CTR с zero-nonce и hex-ключом, сохранить как data: URL.
+//
+// MV3 service worker НЕ имеет URL.createObjectURL (известное ограничение Chrome),
+// поэтому вместо blob URL используем data: URL с base64. chrome.downloads.download
+// принимает их любого размера (ограничено только RAM).
 async function decryptAndDownload(url, key, filename, saveAs) {
   const r = await fetch(url, { credentials: 'omit' });
   if (!r.ok) throw new Error(`fetch encrypted ${r.status}`);
   const encrypted = new Uint8Array(await r.arrayBuffer());
 
-  // hex key → Uint8Array
+  // hex key → bytes
   const keyBytes = new Uint8Array(key.length / 2);
   for (let i = 0; i < keyBytes.length; i++) {
     keyBytes[i] = parseInt(key.substr(i * 2, 2), 16);
@@ -115,20 +119,26 @@ async function decryptAndDownload(url, key, filename, saveAs) {
   const cryptoKey = await crypto.subtle.importKey(
     'raw', keyBytes, { name: 'AES-CTR' }, false, ['decrypt']
   );
-  // 16 байт всего: 12 байт nonce (нули) + 4 байта counter. length=32 bits.
-  // Эквивалент pycryptodome AES.new(key, MODE_CTR, nonce=bytes(12)).
+  // AES-CTR с zero-nonce (12 байт нулей + 4 байта counter). length=32 bits.
   const counter = new Uint8Array(16);
-  const decrypted = await crypto.subtle.decrypt(
+  const decryptedBuf = await crypto.subtle.decrypt(
     { name: 'AES-CTR', counter, length: 32 }, cryptoKey, encrypted
   );
+  const bytes = new Uint8Array(decryptedBuf);
 
-  const blob = new Blob([decrypted]);
-  const blobUrl = URL.createObjectURL(blob);
+  // Конвертация в base64 чанками — чтобы не упасть на stack overflow в apply().
+  const chunkSize = 0x8000;
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode.apply(null, bytes.subarray(i, i + chunkSize));
+  }
+  const base64 = btoa(binary);
+  const dataUrl = `data:application/octet-stream;base64,${base64}`;
+
   return new Promise(resolve => {
-    chrome.downloads.download({ url: blobUrl, filename, saveAs: !!saveAs }, (id) => {
-      setTimeout(() => { try { URL.revokeObjectURL(blobUrl); } catch {} }, 30000);
+    chrome.downloads.download({ url: dataUrl, filename, saveAs: !!saveAs }, (id) => {
       if (chrome.runtime.lastError) resolve({ ok: false, error: chrome.runtime.lastError.message });
-      else resolve({ ok: true, downloadId: id, size: decrypted.byteLength });
+      else resolve({ ok: true, downloadId: id, size: bytes.length });
     });
   });
 }

--- a/content.js
+++ b/content.js
@@ -113,19 +113,42 @@
     });
   }
 
+  async function dispatchDownload(result, filename) {
+    // result либо строка (прямой URL), либо {url, key, encrypted} для AES-CTR потока.
+    if (result && typeof result === 'object' && result.encrypted && result.key) {
+      return new Promise((resolve) => {
+        chrome.runtime.sendMessage(
+          { action: 'downloadEncrypted', url: result.url, key: result.key, filename, saveAs: false },
+          (resp) => {
+            if (chrome.runtime.lastError) resolve({ success: false, error: chrome.runtime.lastError.message });
+            else if (resp?.ok) resolve({ success: true, filename });
+            else resolve({ success: false, error: resp?.error || 'decrypt failed' });
+          }
+        );
+      });
+    }
+    const url = typeof result === 'string' ? result : result?.url;
+    if (!url) return { success: false, error: 'нет URL' };
+    return await downloadFile(url, filename);
+  }
+
   async function downloadCurrentTrack() {
     const info = getCurrentPlayerInfo();
     if (!info.trackId) { showNotification('Включите трек', 'error'); return { success: false, error: 'Нет трека' }; }
     try {
       showNotification('Получаю аудио...', 'loading');
       const track = { trackId: info.trackId, albumId: info.albumId, title: info.title, artist: info.artist, origin: ORIGIN };
-      const audioUrl = await yandex.getAudioUrl(track, { preferCaptured: true, getCapturedAudio });
-      if (!audioUrl) {
+      const result = await yandex.getAudioUrl(track, { preferCaptured: true, getCapturedAudio });
+      if (!result) {
         showNotification('Нет URL. Переключите трек и попробуйте снова.', 'error');
         return { success: false, error: 'Нет URL. Переключите трек.' };
       }
       const fn = yandex.getFilename(track) || `track_${info.trackId}.mp3`;
-      await downloadFile(audioUrl, fn);
+      const dl = await dispatchDownload(result, fn);
+      if (!dl.success) {
+        showNotification('Ошибка скачки: ' + (dl.error || ''), 'error');
+        return dl;
+      }
       const qualityLabel = track._codec ? ` [${String(track._codec).toUpperCase()}${track._bitrate ? ' ' + track._bitrate : ''}]` : '';
       showNotification('✓ ' + fn + qualityLabel, 'success');
       return { success: true, filename: fn };
@@ -139,11 +162,16 @@
     try {
       showNotification('Получаю ссылку...', 'loading');
       const track = { trackId, albumId, title: titleInfo?.title || '', artist: titleInfo?.artist || '', origin: ORIGIN };
-      const audioUrl = await yandex.getAudioUrl(track, {});
-      if (audioUrl) {
+      const result = await yandex.getAudioUrl(track, {});
+      if (result) {
         const fn = yandex.getFilename(track) || `track_${trackId}.mp3`;
-        await downloadFile(audioUrl, fn);
-        showNotification('✓ ' + fn, 'success');
+        const dl = await dispatchDownload(result, fn);
+        if (!dl.success) {
+          showNotification('Ошибка: ' + (dl.error || ''), 'error');
+          return dl;
+        }
+        const qualityLabel = track._codec ? ` [${String(track._codec).toUpperCase()}]` : '';
+        showNotification('✓ ' + fn + qualityLabel, 'success');
         return { success: true, filename: fn };
       }
       showNotification('Включите этот трек, затем нажмите скачать снова', 'error');

--- a/desktop/requirements.txt
+++ b/desktop/requirements.txt
@@ -1,2 +1,4 @@
 PySide6>=6.5
 yt-dlp>=2024.10.07
+pycryptodome>=3.20.0
+

--- a/desktop/window.py
+++ b/desktop/window.py
@@ -269,13 +269,15 @@ class MainWindow(QMainWindow):
         )
         yam_qual_row.addWidget(yam_qual_label)
         self.yam_quality_combo = QComboBox()
-        self.yam_quality_combo.addItem('Авто (MP3 320)', 'auto')
+        self.yam_quality_combo.addItem('Авто — FLAC если есть, иначе MP3 320', 'auto')
+        self.yam_quality_combo.addItem('FLAC (lossless, нужен Я.Плюс)', 'flac')
         self.yam_quality_combo.addItem('MP3 320 kbps', 'mp3-320')
         self.yam_quality_combo.setToolTip(
-            'MP3 320 kbps — ~10 МБ/трек. Звучит как lossless на 99% устройств.\n\n'
-            '⚠ FLAC временно недоступен: Яндекс ограничил lossless только для официальных\n'
-            'мобильных приложений (требуется device attestation которую десктоп/расширение\n'
-            'не могут дать). Любые сторонние программы получают 403 на FLAC.'
+            'Авто — лучшее доступное (FLAC если есть, иначе MP3 320).\n'
+            'FLAC — lossless ~30-50 МБ. Поток зашифрован AES-CTR, программа расшифровывает\n'
+            '(нужен pycryptodome — pip install pycryptodome). Если у трека нет lossless-мастера\n'
+            'или токен без Plus-доступа — будет ошибка.\n'
+            'MP3 320 — ~10 МБ. Работает у всех включая бесплатных.'
         )
         self.yam_quality_combo.currentIndexChanged.connect(self._save_settings)
         yam_qual_row.addWidget(self.yam_quality_combo)

--- a/desktop/yandex_music.py
+++ b/desktop/yandex_music.py
@@ -18,6 +18,7 @@
 """
 from __future__ import annotations
 
+import base64
 import hashlib
 import hmac
 import json
@@ -31,6 +32,8 @@ from typing import Callable, Optional
 API_BASE = 'https://api.music.yandex.net'
 SIGN_SALT = 'XGRlBW9FXlekgbPrRHuSiA'
 V2_HMAC_KEY = b'p93jhgh689SBReK6ghtw62'
+V2_CODECS = 'flac,flac-mp4,mp3,aac,he-aac,aac-mp4,he-aac-mp4'
+V2_TRANSPORTS = 'encraw'
 OAUTH_URL = (
     'https://oauth.yandex.ru/authorize?response_type=token'
     '&client_id=23cabbbdc6cd418abb4b39c32c41195d'
@@ -214,21 +217,35 @@ def _pick_stream(dl_info: list, quality: str) -> Optional[dict]:
 
 # ─────────────────────── Audio URL resolution ───────────────────────
 
-def _get_file_info_v2(track_id: str, token: str, quality: str = 'lossless') -> Optional[dict]:
-    """Новый эндпоинт /get-file-info с HMAC-подписью. Даёт прямой URL для FLAC
-    при наличии мобильного OAuth-токена. Возвращает result-словарь или None если
-    эндпоинт отказал."""
+def _make_v2_sign(ts: int, track_id: str) -> str:
+    """Подпись base64(HMAC-SHA256)[:-1] от склейки значений без запятых."""
+    codecs_nosep = V2_CODECS.replace(',', '')
+    msg = f'{ts}{track_id}lossless{codecs_nosep}{V2_TRANSPORTS}'
+    digest = hmac.new(V2_HMAC_KEY, msg.encode('utf-8'), hashlib.sha256).digest()
+    return base64.b64encode(digest).decode('ascii')[:-1]
+
+
+def _get_file_info_v2(track_id: str, token: str) -> Optional[dict]:
+    """/get-file-info с правильной подписью. Возвращает downloadInfo dict
+    (codec, urls[], key, bitrate, transport=encraw)."""
     ts = int(time.time())
-    codecs = 'flac,aac,mp3'
-    transports = 'raw'
-    sign = hmac.new(V2_HMAC_KEY, f'{ts}{track_id}{codecs}{transports}'.encode(), hashlib.sha256).hexdigest()
-    url = (f'{API_BASE}/get-file-info?ts={ts}&trackId={track_id}'
-           f'&quality={quality}&codecs={codecs}&transports={transports}&sign={sign}')
+    sign = _make_v2_sign(ts, track_id)
+    params = urllib.parse.urlencode({
+        'ts': ts,
+        'trackId': track_id,
+        'quality': 'lossless',
+        'codecs': V2_CODECS,
+        'transports': V2_TRANSPORTS,
+        'sign': sign,
+    })
+    url = f'{API_BASE}/get-file-info?{params}'
     try:
         req = urllib.request.Request(url, headers=_headers(token))
         with urllib.request.urlopen(req, timeout=30) as resp:
             data = json.loads(resp.read().decode('utf-8'))
-        return data.get('result', data)
+        info = data.get('result', data)
+        # response shape: {"result": {"downloadInfo": {...}}} или просто {...}
+        return info.get('downloadInfo', info) if isinstance(info, dict) else None
     except urllib.error.HTTPError as e:
         body = ''
         try:
@@ -238,19 +255,36 @@ def _get_file_info_v2(track_id: str, token: str, quality: str = 'lossless') -> O
         raise RuntimeError(f'/get-file-info {e.code}: {body}')
 
 
+def _aes_ctr_decrypt(data: bytes, hex_key: str) -> bytes:
+    """AES-CTR расшифровка с zero-nonce (как в pycryptodome AES.MODE_CTR с nonce=bytes(12))."""
+    try:
+        from Crypto.Cipher import AES
+    except ImportError:
+        raise RuntimeError(
+            'Для FLAC нужна библиотека pycryptodome. Установи: pip install pycryptodome'
+        )
+    key = bytes.fromhex(hex_key)
+    cipher = AES.new(key=key, nonce=bytes(12), mode=AES.MODE_CTR)
+    return cipher.decrypt(data)
+
+
 def _resolve_audio_url(track: dict, token: str, quality: str = 'auto') -> Optional[tuple]:
-    """Returns (url, codec) or None. Raises RuntimeError если FLAC запрошен но недоступен."""
-    # V2 для FLAC и Auto
+    """Returns (url, codec, encrypted_key) or None.
+    Если encrypted_key != None — поток зашифрован AES-CTR, надо расшифровать."""
+    # V2 для FLAC и Auto: возвращает зашифрованный поток + ключ
     if quality in ('flac', 'auto', '', None):
         try:
-            v2 = _get_file_info_v2(track['trackId'], token, 'lossless')
+            v2 = _get_file_info_v2(track['trackId'], token)
             v2_codec = _norm_codec(v2.get('codec') if v2 else '')
             v2_urls = v2.get('urls') if v2 else None
-            v2_url = v2_urls[0] if v2_urls else v2.get('downloadInfoUrl') if v2 else None
-            if v2_url and v2_codec:
-                if quality != 'flac' or v2_codec == 'flac':
-                    print(f"[YM] V2: {v2_codec} {v2.get('bitrate')}kbps · direct URL")
-                    return (v2_url, v2_codec)
+            v2_url = v2_urls[0] if v2_urls else None
+            v2_key = v2.get('key') if v2 else None
+            if v2_url and v2_codec and v2_key:
+                is_flac = v2_codec in ('flac', 'flac-mp4')
+                if quality != 'flac' or is_flac:
+                    final_codec = 'flac' if is_flac else v2_codec
+                    print(f"[YM] V2: {v2_codec} {v2.get('bitrate')}kbps · encrypted (AES-CTR)")
+                    return (v2_url, final_codec, v2_key)
                 print(f"[YM] V2 вернул не-FLAC ({v2_codec}), fallback на V1")
         except Exception as e:
             print(f"[YM] V2 failed: {e}")
@@ -258,11 +292,10 @@ def _resolve_audio_url(track: dict, token: str, quality: str = 'auto') -> Option
                 msg = str(e)
                 is_auth = '403' in msg or 'not-allowed' in msg
                 raise RuntimeError(
-                    'FLAC недоступен: текущий токен не имеет доступа к lossless. '
-                    'Получи мобильный OAuth-токен через кнопку «Получить» — он даёт нужный scope.'
+                    'FLAC недоступен: токен без lossless-доступа. '
+                    'Попробуй залогиниться на music.yandex.ru заново и пройти OAuth.'
                     if is_auth else f'FLAC недоступен: {msg}'
                 )
-            # Для auto — fallback на V1
 
     # V1 — /download-info
     dl_info = _api_get(f"/tracks/{track['trackId']}/download-info", token)
@@ -296,7 +329,8 @@ def _resolve_audio_url(track: dict, token: str, quality: str = 'auto') -> Option
     if not host or not path or s is None or ts is None:
         return None
     sign = hashlib.md5((SIGN_SALT + path[1:] + s).encode('utf-8')).hexdigest()
-    return (f'https://{host}/get-mp3/{sign}/{ts}{path}', pick.get('codec', 'mp3'))
+    # V1 returns plain URL (no encryption key)
+    return (f'https://{host}/get-mp3/{sign}/{ts}{path}', pick.get('codec', 'mp3'), None)
 
 
 # ─────────────────────── Public entry point ───────────────────────
@@ -395,7 +429,7 @@ def _download_one(track: dict, out_dir: Path, token: str,
     result = _resolve_audio_url(track, token, quality)
     if not result:
         raise RuntimeError(f'Я.Музыка: нет audio URL для трека {track["trackId"]}')
-    audio_url, codec = result
+    audio_url, codec, encryption_key = result
     ext = _ext_for_codec(codec)
 
     artist = _sanitize(track.get('artist', ''))
@@ -407,20 +441,37 @@ def _download_one(track: dict, out_dir: Path, token: str,
     req = urllib.request.Request(audio_url, headers=_headers(None))
     with urllib.request.urlopen(req, timeout=60) as resp:
         total = int(resp.headers.get('Content-Length') or 0) or None
-        downloaded = 0
-        with open(out_path, 'wb') as f:
+        if encryption_key:
+            # V2 поток — зашифрован, читаем всё в память, расшифровываем, пишем.
+            chunks = []
+            downloaded = 0
             while True:
                 if cancel_check():
                     raise YMCancelled()
-                chunk = resp.read(128 * 1024)
+                chunk = resp.read(256 * 1024)
                 if not chunk:
                     break
-                f.write(chunk)
+                chunks.append(chunk)
                 downloaded += len(chunk)
-                progress_cb({
-                    'status': 'downloading',
-                    'downloaded_bytes': downloaded,
-                    'total_bytes': total,
-                })
+                progress_cb({'status': 'downloading',
+                             'downloaded_bytes': downloaded, 'total_bytes': total})
+            encrypted = b''.join(chunks)
+            decrypted = _aes_ctr_decrypt(encrypted, encryption_key)
+            with open(out_path, 'wb') as f:
+                f.write(decrypted)
+        else:
+            # V1 — поток нешифрованный, стримим напрямую в файл
+            downloaded = 0
+            with open(out_path, 'wb') as f:
+                while True:
+                    if cancel_check():
+                        raise YMCancelled()
+                    chunk = resp.read(128 * 1024)
+                    if not chunk:
+                        break
+                    f.write(chunk)
+                    downloaded += len(chunk)
+                    progress_cb({'status': 'downloading',
+                                 'downloaded_bytes': downloaded, 'total_bytes': total})
     progress_cb({'status': 'finished'})
     return out_path

--- a/popup.html
+++ b/popup.html
@@ -55,19 +55,19 @@
         Качество <span class="muted">(Я.Музыка)</span>
       </label>
       <select id="quality-select" class="quality-select">
-        <option value="auto">Авто (MP3 320)</option>
+        <option value="auto">Авто — FLAC если есть, иначе MP3 320</option>
+        <option value="flac">FLAC (lossless, нужен Я.Плюс)</option>
         <option value="mp3-320">MP3 320 kbps</option>
       </select>
     </div>
     <details class="quality-help">
-      <summary>про качество и FLAC</summary>
+      <summary>что выбрать?</summary>
       <div class="quality-help-body">
-        <p><b>MP3 320 kbps</b> — ~10 МБ/трек. Звучит как lossless на 99% аудиоустройств.</p>
-        <p style="margin-top:8px; color: rgba(255,180,77,0.85)">
-          <b>⚠ FLAC временно недоступен.</b> Яндекс с 2026 года ограничил lossless только для официальных мобильных приложений (требуется device attestation которую браузер дать не может). Любые расширения и сторонние программы получают <code>403 not-allowed</code> на FLAC. Это касается всех downloader'ов, не только этого.
-        </p>
+        <p><b>Авто</b> — берёт FLAC если Плюс + у трека есть lossless, иначе MP3 320. Рекомендую.</p>
+        <p><b>FLAC</b> — lossless ~30-50 МБ. Поток зашифрован, расшифровываем в коде через AES-CTR. Если у трека нет lossless-мастера — пишет ошибку.</p>
+        <p><b>MP3 320</b> — ~10 МБ. Работает у всех (даже без Плюса).</p>
         <p style="margin-top:8px; color: rgba(255,255,255,0.4)">
-          Если найдём обходной путь — добавим обратно.
+          FLAC использует новый эндпоинт <code>/get-file-info</code> с HMAC-подписью + AES-CTR расшифровка. Если 403 — обычно нужно зайти на music.yandex.ru заново и подождать пока расширение поймает новый токен.
         </p>
       </div>
     </details>

--- a/services/yandex.js
+++ b/services/yandex.js
@@ -59,33 +59,43 @@
     }
   }
 
-  // HMAC-ключ для V2 (/get-file-info) — из публичных yandex-music API реверсов
+  // HMAC-ключ для V2 (/get-file-info) — DEFAULT_SIGN_KEY из yandex-music-api
   const V2_HMAC_KEY = 'p93jhgh689SBReK6ghtw62';
+  // Codecs включают flac-mp4 и he-aac-mp4 — это разные контейнеры/кодировки
+  const V2_CODECS = 'flac,flac-mp4,mp3,aac,he-aac,aac-mp4,he-aac-mp4';
+  const V2_TRANSPORTS = 'encraw';  // encrypted raw — нужна AES-CTR расшифровка
 
-  async function hmacSha256Hex(keyStr, msgStr) {
+  function bytesToBase64(bytes) {
+    let s = '';
+    for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+    return btoa(s);
+  }
+
+  // Подпись для /get-file-info: base64(HMAC-SHA256(KEY, values_joined_without_commas))[:-1]
+  // Формат строгий — codecs передаются с запятыми в URL, но в сообщении подписи
+  // запятые удаляются (особенность Yandex API).
+  async function makeV2Sign(ts, trackId) {
+    const codecsNoSep = V2_CODECS.replace(/,/g, '');
+    const msg = `${ts}${trackId}lossless${codecsNoSep}${V2_TRANSPORTS}`;
     const enc = new TextEncoder();
     const key = await crypto.subtle.importKey(
-      'raw', enc.encode(keyStr),
+      'raw', enc.encode(V2_HMAC_KEY),
       { name: 'HMAC', hash: 'SHA-256' },
       false, ['sign']
     );
-    const sig = await crypto.subtle.sign('HMAC', key, enc.encode(msgStr));
-    return Array.from(new Uint8Array(sig)).map(b => b.toString(16).padStart(2, '0')).join('');
+    const sig = await crypto.subtle.sign('HMAC', key, enc.encode(msg));
+    const b64 = bytesToBase64(new Uint8Array(sig));
+    return b64.slice(0, -1);  // Yandex срезает последний символ (характерная особенность API)
   }
 
-  async function getFileInfoV2(trackId, token, quality) {
-    // Новый эндпоинт api.music.yandex.net/get-file-info с HMAC-подписью.
-    // Возвращает прямой URL (без MD5-sign дополнительного), и поддерживает FLAC
-    // для мобильных OAuth-токенов (web-токен → 403 not-allowed).
+  async function getFileInfoV2(trackId, token) {
     const ts = Math.floor(Date.now() / 1000);
-    const codecs = 'flac,aac,mp3';
-    const transports = 'raw';
-    const sign = await hmacSha256Hex(V2_HMAC_KEY, `${ts}${trackId}${codecs}${transports}`);
+    const sign = await makeV2Sign(ts, trackId);
     const url = `${API_BASE}/get-file-info?ts=${ts}&trackId=${trackId}` +
-      `&quality=${encodeURIComponent(quality)}` +
-      `&codecs=${encodeURIComponent(codecs)}` +
-      `&transports=${encodeURIComponent(transports)}` +
-      `&sign=${sign}`;
+      `&quality=lossless` +
+      `&codecs=${encodeURIComponent(V2_CODECS)}` +
+      `&transports=${V2_TRANSPORTS}` +
+      `&sign=${encodeURIComponent(sign)}`;
     const resp = await fetch(url, { headers: authHeaders(token) });
     if (!resp.ok) {
       const text = await resp.text().catch(() => '');
@@ -94,7 +104,8 @@
       throw new Error(`/get-file-info ${resp.status} ${name || text.slice(0, 100)}`);
     }
     const data = await resp.json();
-    return data.result || data;
+    const info = (data.result && data.result.downloadInfo) || data.downloadInfo || data.result || data;
+    return info;
   }
 
   function normCodec(s) { return String(s || '').toLowerCase(); }
@@ -219,40 +230,40 @@
     const token = await getToken();
 
     if (token) {
-      // Для FLAC и Auto — сначала пробуем V2 эндпоинт /get-file-info (даёт прямой
-      // URL для FLAC). Если токен мобильный (OAuth client_id Яндекс.Музыки) —
-      // получим lossless. Если web-токен — будет 403 not-allowed, фоллбек на V1.
+      // V2 (/get-file-info, encraw) — единственный путь для FLAC. Поток зашифрован
+      // AES-CTR, ключ приходит в ответе → расшифровываем перед сохранением.
       if (quality === 'flac' || quality === 'auto' || !quality) {
         try {
-          const v2 = await getFileInfoV2(track.trackId, token, 'lossless');
-          const v2url = v2?.urls?.[0] || v2?.downloadInfoUrl;
+          const v2 = await getFileInfoV2(track.trackId, token);
+          const v2url = v2?.urls?.[0];
           const v2codec = normCodec(v2?.codec);
-          if (v2url && v2codec) {
-            // Если запросили строго FLAC и получили его — отдаём
-            // Если Auto — отдаём что есть (это лучшее что V2 выдал)
-            if (quality !== 'flac' || v2codec === 'flac') {
-              track._codec = v2.codec;
+          const v2key = v2?.key;
+          if (v2url && v2codec && v2key) {
+            const isFlacResult = v2codec === 'flac' || v2codec === 'flac-mp4';
+            if (quality !== 'flac' || isFlacResult) {
+              track._codec = isFlacResult ? 'flac' : v2codec;
               track._bitrate = v2.bitrate;
-              console.log('[YMD] V2 endpoint:', v2.codec, v2.bitrate, 'kbps · direct URL');
-              return v2url;
+              console.log('[YMD] V2:', v2codec, v2.bitrate, 'kbps · encrypted (AES-CTR)');
+              return {
+                url: v2url,
+                key: v2key,
+                codec: track._codec,
+                bitrate: v2.bitrate,
+                encrypted: true,
+              };
             }
-            console.log('[YMD] V2 вернул не-FLAC (' + v2.codec + '), хотя запросили FLAC. Fallback на V1.');
+            console.log('[YMD] V2 returned non-FLAC (' + v2codec + '), falling back to V1');
           }
         } catch (err) {
-          console.warn('[YMD] V2 endpoint failed:', err.message);
+          console.warn('[YMD] V2 failed:', err.message);
           if (quality === 'flac') {
-            // Строгий FLAC — без V2 не получится. Внятная ошибка.
             const isAuth = /403|not-allowed/i.test(err.message);
             throw new Error(
               isAuth
-                ? 'FLAC недоступен: текущий токен не имеет доступа к lossless. ' +
-                  'Нажми в попапе «Открыть страницу для получения токена» — это ' +
-                  'мобильный OAuth-флоу, он даёт нужный scope для FLAC. ' +
-                  '(Авто-захваченный токен с music.yandex.ru — это web-сессия, у неё нет FLAC.)'
+                ? 'FLAC недоступен: токен без lossless-доступа. Попробуй: 1) залогиниться на music.yandex.ru заново; 2) если есть мобильный Я.Плюс — пройти OAuth заново.'
                 : 'FLAC недоступен: ' + err.message
             );
           }
-          // Для Auto — продолжаем в V1 path
         }
       }
 


### PR DESCRIPTION
## Что нашёл

Юзер скинул 4pda тему про **Murglar** (рабочий downloader). Через GitHub search нашёл **`llistochek/yandex-music-downloader`** — там актуальный рабочий код для FLAC. Мои ошибки в подписи:

| Что было у меня | Что нужно |
|---|---|
| HMAC → hex | HMAC → base64, потом срез последнего символа |
| Message: `ts+trackId+codecs_with_commas+transports` | `ts+trackId+'lossless'+codecs_БЕЗ_запятых+transports` |
| transports=raw | transports=encraw (зашифрованный) |
| codecs=flac,aac,mp3 | codecs=flac,flac-mp4,mp3,aac,he-aac,aac-mp4,he-aac-mp4 |

Проверил curl-ом: с правильной подписью /get-file-info возвращает **HTTP 200** с `downloadInfo {codec, urls, key, bitrate, transport=encraw}`. Anonymous — preview 128kbps. С реальным Plus-токеном — FLAC.

## Что меняется

### Extension
- **`services/yandex.js`**: `bytesToBase64`, `makeV2Sign` (по новой формуле), V2_CODECS/V2_TRANSPORTS обновлены. `getAudioUrl` для V2 возвращает `{url, key, codec, encrypted: true}` вместо строки.
- **`background.js`**: `decryptAndDownload(url, key, filename, saveAs)` — fetch encrypted, AES-CTR decrypt через `crypto.subtle`, save через blob URL. Handler `downloadEncrypted` для content script. `downloadByUrl` в paste-flow знает про encrypted=true.
- **`content.js`**: `dispatchDownload` распознаёт encrypted result, шлёт в background.
- **`popup.html`**: FLAC возвращён в селект.

### Desktop
- **`desktop/yandex_music.py`**: `_make_v2_sign`, `_aes_ctr_decrypt` (через pycryptodome). `_resolve_audio_url` возвращает `(url, codec, key)`. `_download_one` расшифровывает в памяти если есть key.
- **`desktop/window.py`**: FLAC возвращён в комбо.
- **`desktop/requirements.txt`**: + `pycryptodome>=3.20.0`.

## Криптография

`crypto.subtle.decrypt({ name: 'AES-CTR', counter: zero_16_bytes, length: 32 }, key, encrypted)` в JS эквивалентно `AES.new(key, MODE_CTR, nonce=bytes(12))` в pycryptodome — counter из 12 zero nonce + 4 байта auto-incrementing. Все проверял по референсной реализации.

## Test plan

- [ ] CI зелёный
- [ ] С Я.Плюс + 'FLAC' — трек скачивается как .flac, разваривается без ошибок
- [ ] Без Plus + 'FLAC' — ошибка 'недоступен'
- [ ] 'Авто' с Plus — FLAC. Без Plus — MP3 320 (V1 fallback).
- [ ] 'MP3 320' — V1 path (без расшифровки), как раньше.

⚠ Не релизить пока юзер не протестит на своих треках в Я.Плюс.