### PR TITLE
Fix #26: UUID-плейлисты с префиксом (lk.UUID)

### DIFF
--- a/desktop/yandex_music.py
+++ b/desktop/yandex_music.py
@@ -78,7 +78,9 @@ def _parse_url(url: str) -> dict:
     m = re.search(r'/users/([^/]+)/playlists/(\d+)', p)
     if m:
         return {'type': 'playlist', 'owner': m.group(1), 'kinds': m.group(2)}
-    m = re.search(r'/playlists/([a-f0-9-]{32,40})', p, re.I)
+    # UUID-плейлисты могут быть с префиксом типа `lk.` (личные плейлисты).
+    # API /playlist/{uuid} принимает полный идентификатор с префиксом.
+    m = re.search(r'/playlists/((?:[a-z]{1,4}\.)?[a-f0-9-]{32,40})', p, re.I)
     if m:
         return {'type': 'playlist', 'uuid': m.group(1)}
     raise ValueError(

--- a/services/yandex.js
+++ b/services/yandex.js
@@ -26,8 +26,10 @@
     if (m) return { type: 'album', albumId: m[1] };
     m = p.match(/\/users\/([^/]+)\/playlists\/(\d+)/);
     if (m) return { type: 'playlist', owner: m[1], kinds: m[2] };
-    // Новый формат: /playlists/{uuid}  (например 01a6eb8c-578e-8e47-b4b4-bab9aae9da0b)
-    m = p.match(/\/playlists\/([a-f0-9-]{32,40})/i);
+    // Новый формат: /playlists/{uuid}. UUID может быть голый ИЛИ с префиксом
+    // (например `lk.d09349ea-...` — Ласкавая/Лк, личные плейлисты юзера и т.п.).
+    // API эндпоинт /playlist/{uuid} принимает полный идентификатор с префиксом.
+    m = p.match(/\/playlists\/((?:[a-z]{1,4}\.)?[a-f0-9-]{32,40})/i);
     if (m) return { type: 'playlist', uuid: m[1] };
     return null;
   }


### PR DESCRIPTION
Issue #26 — десктоп не распознаёт URL `/playlists/lk.d09349ea-...`.

Префикс `lk.` это новый формат личных плейлистов Я.Музыки. API `/playlist/{uuid}` принимает их с префиксом (проверил curl-ом). Просто расширил regex.

Закрывает #26.