### PR TITLE
v3.5.1: фикс обложки в Windows Explorer (ID3v2.3 + UTF-16)

### DIFF
--- a/background.js
+++ b/background.js
@@ -142,7 +142,7 @@ async function downloadAndTag(opts) {
     let coverBytes = null;
     if (opts.coverUri) {
       try {
-        const coverUrl = coverUriToHttps(opts.coverUri, '1000x1000');
+        const coverUrl = coverUriToHttps(opts.coverUri, '400x400');
         console.log('[YMD] fetching cover:', coverUrl);
         const cr = await fetch(coverUrl, { credentials: 'omit' });
         if (cr.ok) {
@@ -185,7 +185,7 @@ async function downloadAndTag(opts) {
   });
 }
 
-function coverUriToHttps(uri, size = '1000x1000') {
+function coverUriToHttps(uri, size = '400x400') {
   if (!uri) return null;
   if (!uri.startsWith('http')) uri = 'https://' + uri;
   return uri.replace('%%', size);

--- a/background.js
+++ b/background.js
@@ -142,7 +142,7 @@ async function downloadAndTag(opts) {
     let coverBytes = null;
     if (opts.coverUri) {
       try {
-        const coverUrl = coverUriToHttps(opts.coverUri, '400x400');
+        const coverUrl = coverUriToHttps(opts.coverUri, '600x600');
         console.log('[YMD] fetching cover:', coverUrl);
         const cr = await fetch(coverUrl, { credentials: 'omit' });
         if (cr.ok) {
@@ -185,7 +185,7 @@ async function downloadAndTag(opts) {
   });
 }
 
-function coverUriToHttps(uri, size = '400x400') {
+function coverUriToHttps(uri, size = '600x600') {
   if (!uri) return null;
   if (!uri.startsWith('http')) uri = 'https://' + uri;
   return uri.replace('%%', size);

--- a/desktop/yandex_music.py
+++ b/desktop/yandex_music.py
@@ -141,8 +141,8 @@ def _shape_track(t: dict, default_album: str = '') -> dict:
     }
 
 
-def _cover_url_https(uri: str, size: str = '400x400') -> Optional[str]:
-    """avatars.yandex.net/.../%% → https://avatars.yandex.net/.../400x400"""
+def _cover_url_https(uri: str, size: str = '600x600') -> Optional[str]:
+    """avatars.yandex.net/.../%% → https://avatars.yandex.net/.../600x600"""
     if not uri:
         return None
     if not uri.startswith('http'):
@@ -150,7 +150,7 @@ def _cover_url_https(uri: str, size: str = '400x400') -> Optional[str]:
     return uri.replace('%%', size)
 
 
-def _fetch_cover_bytes(uri: str, size: str = '400x400') -> Optional[bytes]:
+def _fetch_cover_bytes(uri: str, size: str = '600x600') -> Optional[bytes]:
     url = _cover_url_https(uri, size)
     if not url:
         return None

--- a/desktop/yandex_music.py
+++ b/desktop/yandex_music.py
@@ -141,8 +141,8 @@ def _shape_track(t: dict, default_album: str = '') -> dict:
     }
 
 
-def _cover_url_https(uri: str, size: str = '1000x1000') -> Optional[str]:
-    """avatars.yandex.net/.../%% → https://avatars.yandex.net/.../1000x1000"""
+def _cover_url_https(uri: str, size: str = '400x400') -> Optional[str]:
+    """avatars.yandex.net/.../%% → https://avatars.yandex.net/.../400x400"""
     if not uri:
         return None
     if not uri.startswith('http'):
@@ -150,7 +150,7 @@ def _cover_url_https(uri: str, size: str = '1000x1000') -> Optional[str]:
     return uri.replace('%%', size)
 
 
-def _fetch_cover_bytes(uri: str, size: str = '1000x1000') -> Optional[bytes]:
+def _fetch_cover_bytes(uri: str, size: str = '400x400') -> Optional[bytes]:
     url = _cover_url_https(uri, size)
     if not url:
         return None
@@ -192,13 +192,16 @@ def _embed_metadata_and_cover(file_path: Path, codec: str, track: dict,
             except ID3NoHeaderError:
                 audio = ID3()
             audio.delall('APIC')
-            if title: audio.add(TIT2(encoding=3, text=title))
-            if artist: audio.add(TPE1(encoding=3, text=artist))
-            if album: audio.add(TALB(encoding=3, text=album))
-            if year: audio.add(TDRC(encoding=3, text=year))
+            # encoding=1 (UTF-16) валиден в ID3v2.3. encoding=3 (UTF-8) невалиден
+            # в 2.3 и Windows Explorer игнорирует такие теги/обложку.
+            if title: audio.add(TIT2(encoding=1, text=title))
+            if artist: audio.add(TPE1(encoding=1, text=artist))
+            if album: audio.add(TALB(encoding=1, text=album))
+            if year: audio.add(TDRC(encoding=1, text=year))
             if cover_bytes:
-                audio.add(APIC(encoding=3, mime='image/jpeg', type=3, desc='', data=cover_bytes))
-            audio.save(file_path)
+                audio.add(APIC(encoding=0, mime='image/jpeg', type=3, desc='', data=cover_bytes))
+            # v2_version=3 — пишем строго ID3v2.3 (Win Explorer читает лучше 2.4)
+            audio.save(file_path, v2_version=3)
         elif is_flac:
             from mutagen.flac import FLAC, Picture
             audio = FLAC(file_path)

--- a/lib/id3.js
+++ b/lib/id3.js
@@ -26,26 +26,49 @@
     return new Uint8Array([(n >> 21) & 0x7f, (n >> 14) & 0x7f, (n >> 7) & 0x7f, n & 0x7f]);
   }
 
+  function asciiBytes(str) {
+    const out = new Uint8Array(str.length);
+    for (let i = 0; i < str.length; i++) out[i] = str.charCodeAt(i) & 0x7f;
+    return out;
+  }
+
+  // UTF-16LE с BOM + двойной нулевой терминатор. В ID3v2.3 это encoding 0x01.
+  // ID3v2.3 НЕ поддерживает UTF-8 (0x03) — Windows Explorer такие теги
+  // игнорирует. UTF-16 — единственный способ записать кириллицу в 2.3.
+  function utf16leWithBom(str) {
+    const s = String(str);
+    const out = new Uint8Array(2 + s.length * 2 + 2);
+    out[0] = 0xff; out[1] = 0xfe;  // BOM (little-endian)
+    let p = 2;
+    for (let i = 0; i < s.length; i++) {
+      const c = s.charCodeAt(i);
+      out[p++] = c & 0xff;
+      out[p++] = (c >> 8) & 0xff;
+    }
+    out[p++] = 0x00; out[p++] = 0x00;  // terminator
+    return out;
+  }
+
   function textFrame(id, text) {
     if (!text) return new Uint8Array(0);
-    const enc = new TextEncoder();
-    // UTF-8 encoding (0x03) + payload + (опц.) terminator
-    const body = concat(new Uint8Array([0x03]), enc.encode(String(text)));
-    const head = concat(enc.encode(id), be32(body.length), new Uint8Array([0, 0]));
+    // encoding 0x01 = UTF-16 with BOM (валидно в ID3v2.3)
+    const body = concat(new Uint8Array([0x01]), utf16leWithBom(text));
+    const head = concat(asciiBytes(id), be32(body.length), new Uint8Array([0, 0]));
     return concat(head, body);
   }
 
   function apicFrame(imageBytes, mime) {
-    const enc = new TextEncoder();
+    // APIC: encoding 0x00 (ISO-8859-1) — description пустой, mime это ASCII,
+    // так максимально совместимо. Picture data от encoding не зависит.
     const body = concat(
-      new Uint8Array([0x03]),                  // text encoding UTF-8
-      enc.encode(mime || 'image/jpeg'),        // MIME
+      new Uint8Array([0x00]),                  // text encoding ISO-8859-1
+      asciiBytes(mime || 'image/jpeg'),        // MIME (ASCII)
       new Uint8Array([0x00]),                  // MIME terminator
-      new Uint8Array([0x03]),                  // picture type: cover (front)
-      new Uint8Array([0x00]),                  // description terminator (empty desc)
+      new Uint8Array([0x03]),                  // picture type: 3 = cover (front)
+      new Uint8Array([0x00]),                  // empty description terminator
       imageBytes,
     );
-    const head = concat(enc.encode('APIC'), be32(body.length), new Uint8Array([0, 0]));
+    const head = concat(asciiBytes('APIC'), be32(body.length), new Uint8Array([0, 0]));
     return concat(head, body);
   }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Music Downloader (Я.Музыка / Bandcamp / SoundCloud)",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Скачивайте треки, альбомы и плейлисты с Яндекс Музыки, Bandcamp и SoundCloud — на странице или по ссылке из попапа.",
   "permissions": [
     "activeTab",


### PR DESCRIPTION
Корень: писал ID3v2.3 header но encoding 0x03 (UTF-8) — невалиден в 2.3. Windows Explorer игнорировал тег. AIMP прощал. Размер обложки был ни при чём.

Фикс: UTF-16 (encoding 0x01) для текста, ISO-8859-1 для APIC. Десктоп — mutagen encoding=1 + save(v2_version=3). Обложка 600×600.

Проверено: тег парсится как ID3v2.3.0, кириллица OK, APIC валиден. Closes cover-art issue.