### PR TITLE
v3.5.2: фикс — на «Авто» качался AAC 265 в .mp3 вместо MP3 320

### DIFF
--- a/desktop/yandex_music.py
+++ b/desktop/yandex_music.py
@@ -269,10 +269,10 @@ def _fetch_single_track(track_id: str, album_id: Optional[str], token: Optional[
 
 def _ext_for_codec(codec: str) -> str:
     c = (codec or '').lower()
-    if c == 'flac':
+    if c in ('flac', 'flac-mp4'):
         return 'flac'
-    if c in ('aac', 'he-aac'):
-        return 'aac'
+    if c in ('aac', 'he-aac', 'aac-mp4', 'he-aac-mp4'):
+        return 'm4a'  # AAC-в-MP4 → .m4a (правильное расширение)
     if c == 'opus':
         return 'opus'
     return 'mp3'
@@ -373,21 +373,13 @@ def _aes_ctr_decrypt(data: bytes, hex_key: str) -> bytes:
 def _resolve_audio_url(track: dict, token: str, quality: str = 'auto') -> Optional[tuple]:
     """Returns (url, codec, encrypted_key) or None.
     Если encrypted_key != None — поток зашифрован AES-CTR, надо расшифровать."""
-    # V2 для FLAC и Auto: возвращает зашифрованный поток + ключ
+    # V2 (/get-file-info) — путь ТОЛЬКО для FLAC. Принимаем результат
+    # ИСКЛЮЧИТЕЛЬНО если это FLAC. Если V2 отдаёт aac-mp4/mp3 — это не то что
+    # обещает "Авто" (FLAC → иначе MP3 320), откатываемся на V1 за чистым MP3.
     if quality in ('flac', 'auto', '', None):
+        v2 = None
         try:
             v2 = _get_file_info_v2(track['trackId'], token)
-            v2_codec = _norm_codec(v2.get('codec') if v2 else '')
-            v2_urls = v2.get('urls') if v2 else None
-            v2_url = v2_urls[0] if v2_urls else None
-            v2_key = v2.get('key') if v2 else None
-            if v2_url and v2_codec and v2_key:
-                is_flac = v2_codec in ('flac', 'flac-mp4')
-                if quality != 'flac' or is_flac:
-                    final_codec = 'flac' if is_flac else v2_codec
-                    print(f"[YM] V2: {v2_codec} {v2.get('bitrate')}kbps · encrypted (AES-CTR)")
-                    return (v2_url, final_codec, v2_key)
-                print(f"[YM] V2 вернул не-FLAC ({v2_codec}), fallback на V1")
         except Exception as e:
             print(f"[YM] V2 failed: {e}")
             if quality == 'flac':
@@ -398,6 +390,24 @@ def _resolve_audio_url(track: dict, token: str, quality: str = 'auto') -> Option
                     'Попробуй залогиниться на music.yandex.ru заново и пройти OAuth.'
                     if is_auth else f'FLAC недоступен: {msg}'
                 )
+            # quality='auto' → проглатываем, идём в V1 за MP3
+        if v2:
+            v2_codec = _norm_codec(v2.get('codec'))
+            v2_urls = v2.get('urls')
+            v2_url = v2_urls[0] if v2_urls else None
+            v2_key = v2.get('key')
+            is_flac = v2_codec in ('flac', 'flac-mp4')
+            if v2_url and v2_key and is_flac:
+                print(f"[YM] V2 FLAC: {v2_codec} {v2.get('bitrate')}kbps · encrypted")
+                return (v2_url, 'flac', v2_key)
+            # V2 не дал FLAC
+            if quality == 'flac':
+                raise RuntimeError(
+                    f'FLAC недоступен для этого трека — нет lossless-мастера'
+                    + (f' (API отдаёт только {v2_codec})' if v2_codec else '')
+                    + '. Выбери «MP3 320» или «Авто».'
+                )
+            print(f"[YM] V2 без FLAC ({v2_codec}), беру MP3 320 через V1")
 
     # V1 — /download-info
     dl_info = _api_get(f"/tracks/{track['trackId']}/download-info", token)

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Music Downloader (Я.Музыка / Bandcamp / SoundCloud)",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Скачивайте треки, альбомы и плейлисты с Яндекс Музыки, Bandcamp и SoundCloud — на странице или по ссылке из попапа.",
   "permissions": [
     "activeTab",

--- a/services/yandex.js
+++ b/services/yandex.js
@@ -52,9 +52,12 @@
 
   function extForCodec(codec) {
     switch ((codec || '').toLowerCase()) {
-      case 'flac': return 'flac';
+      case 'flac':
+      case 'flac-mp4': return 'flac';
       case 'aac':
-      case 'he-aac': return 'aac';
+      case 'he-aac':
+      case 'aac-mp4':
+      case 'he-aac-mp4': return 'm4a';  // AAC-в-MP4 → .m4a (правильное расширение)
       case 'opus': return 'opus';
       case 'mp3':
       default: return 'mp3';
@@ -254,30 +257,13 @@
     const token = await getToken();
 
     if (token) {
-      // V2 (/get-file-info, encraw) — единственный путь для FLAC. Поток зашифрован
-      // AES-CTR, ключ приходит в ответе → расшифровываем перед сохранением.
+      // V2 (/get-file-info, encraw) — путь ТОЛЬКО для FLAC. Принимаем результат
+      // ИСКЛЮЧИТЕЛЬНО если это FLAC. Если V2 вернул aac/aac-mp4/mp3 — это НЕ то
+      // что обещает "Авто" (FLAC → иначе MP3 320). Откатываемся на V1 за чистым MP3.
       if (quality === 'flac' || quality === 'auto' || !quality) {
+        let v2 = null;
         try {
-          const v2 = await getFileInfoV2(track.trackId, token);
-          const v2url = v2?.urls?.[0];
-          const v2codec = normCodec(v2?.codec);
-          const v2key = v2?.key;
-          if (v2url && v2codec && v2key) {
-            const isFlacResult = v2codec === 'flac' || v2codec === 'flac-mp4';
-            if (quality !== 'flac' || isFlacResult) {
-              track._codec = isFlacResult ? 'flac' : v2codec;
-              track._bitrate = v2.bitrate;
-              console.log('[YMD] V2:', v2codec, v2.bitrate, 'kbps · encrypted (AES-CTR)');
-              return {
-                url: v2url,
-                key: v2key,
-                codec: track._codec,
-                bitrate: v2.bitrate,
-                encrypted: true,
-              };
-            }
-            console.log('[YMD] V2 returned non-FLAC (' + v2codec + '), falling back to V1');
-          }
+          v2 = await getFileInfoV2(track.trackId, token);
         } catch (err) {
           console.warn('[YMD] V2 failed:', err.message);
           if (quality === 'flac') {
@@ -288,10 +274,32 @@
                 : 'FLAC недоступен: ' + err.message
             );
           }
+          // quality='auto' → проглатываем, идём в V1 за MP3
+        }
+        if (v2) {
+          const v2url = v2.urls?.[0];
+          const v2codec = normCodec(v2.codec);
+          const v2key = v2.key;
+          const isFlacResult = v2codec === 'flac' || v2codec === 'flac-mp4';
+          if (v2url && v2key && isFlacResult) {
+            track._codec = 'flac';
+            track._bitrate = v2.bitrate;
+            console.log('[YMD] V2 FLAC:', v2codec, v2.bitrate, 'kbps · encrypted');
+            return { url: v2url, key: v2key, codec: 'flac', bitrate: v2.bitrate, encrypted: true };
+          }
+          // V2 не дал FLAC (вернул aac/mp3/etc)
+          if (quality === 'flac') {
+            throw new Error(
+              'FLAC недоступен для этого трека — нет lossless-мастера' +
+              (v2codec ? ' (API отдаёт только ' + v2codec + ')' : '') +
+              '. Выбери «MP3 320» или «Авто».'
+            );
+          }
+          console.log('[YMD] V2 без FLAC (' + v2codec + '), беру MP3 320 через V1');
         }
       }
 
-      // V1 path — /tracks/X/download-info (для MP3 и как fallback)
+      // V1 path — /tracks/X/download-info (чистый MP3, без MP4-контейнера)
       const dlInfo = await apiGet(`/tracks/${track.trackId}/download-info`, token);
       if (!Array.isArray(dlInfo) || !dlInfo.length) throw new Error('Я.Музыка не вернула download-info');
 


### PR DESCRIPTION
Юзер Константин (v3.5.1): «MP3 качается только 265 kbit». MediaInfo: файл .mp3 содержит **AAC LC 265 в MP4-контейнере**.

## Корень
При quality='auto' код шёл в V2 (/get-file-info за FLAC). Для трека без lossless V2 отдаёт `aac-mp4`. Старое условие принимало любой V2 результат для 'auto' → отдавал AAC. Плюс `extForCodec('aac-mp4')` → default `.mp3`. Итог: AAC 265 в .mp3 файле.

«Авто» обещает FLAC → иначе **MP3 320**, не AAC.

## Фикс (расширение + десктоп)
- V2 принимаем **только если codec = flac/flac-mp4**. Иначе для 'auto' → откат на V1 → честный MP3 320. Для 'flac' → внятная ошибка.
- extForCodec: flac-mp4→flac, aac-mp4→m4a (правильное расширение если AAC всё же сохранится).

## Проверка
- Авто + FLAC есть → FLAC
- Авто + FLAC нет → MP3 320 (настоящий MPEG, не MP4)
- MP3 320 явно → V1 MP3 320

Closes Константин's report.