### PR TITLE
v3.8.0: текст песни вшивается в трек (USLT/LYRICS/©lyr)

### DIFF
--- a/background.js
+++ b/background.js
@@ -165,11 +165,11 @@ async function downloadAndTag(opts) {
   }
 
   // MP3 → ID3v2 APIC
-  if (realContainer === 'mp3' && (coverBytes || opts.title || opts.artist || opts.album)) {
+  if (realContainer === 'mp3' && (coverBytes || opts.title || opts.artist || opts.album || opts.lyrics)) {
     try {
       const tag = globalThis.YMD_ID3.buildID3v2({
         title: opts.title, artist: opts.artist, album: opts.album,
-        year: opts.year, cover: coverBytes, coverMime: 'image/jpeg',
+        year: opts.year, lyrics: opts.lyrics, cover: coverBytes, coverMime: 'image/jpeg',
       });
       bytes = globalThis.YMD_ID3.prependID3v2ToMP3(bytes, tag);
       debug.tagged = true;
@@ -183,7 +183,7 @@ async function downloadAndTag(opts) {
   if (realContainer === 'm4a') {
     const tagOpts = {
       title: opts.title, artist: opts.artist, album: opts.album, year: opts.year,
-      cover: coverBytes, coverMime: 'image/jpeg',
+      lyrics: opts.lyrics, cover: coverBytes, coverMime: 'image/jpeg',
     };
     let remuxed = false;
     if (opts.flacNative) {
@@ -202,7 +202,7 @@ async function downloadAndTag(opts) {
         console.warn('[YMD] flac remux skip (не FLAC или ошибка):', e.message);
       }
     }
-    if (!remuxed && (coverBytes || opts.title || opts.artist || opts.album)) {
+    if (!remuxed && (coverBytes || opts.title || opts.artist || opts.album || opts.lyrics)) {
       try {
         bytes = globalThis.YMD_MP4.addCoverToMp4(bytes, tagOpts);
         debug.tagged = true;
@@ -285,6 +285,7 @@ async function downloadByUrl(rawUrl) {
 
   const saveAs = await getSaveAs();
   const flacNative = await new Promise(r => chrome.storage.local.get('yamFlacNative', d => r(d?.yamFlacNative !== false)));
+  const wantLyrics = await new Promise(r => chrome.storage.local.get('yamLyrics', d => r(!!(d && d.yamLyrics))));
   const folder = service.name; // subfolder per service for batch downloads
   let downloaded = 0;
   const isBatch = tracks.length > 1;
@@ -294,6 +295,10 @@ async function downloadByUrl(rawUrl) {
     const labelTitle = (t.artist && t.title) ? `${t.artist} - ${t.title}` : (t.title || `track ${i + 1}`);
     pushProgress({ status: 'progress', current: i + 1, total: tracks.length, title: labelTitle });
     try {
+      // Текст песни (если включено и сервис Я.Музыка)
+      if (wantLyrics && service.name === 'yandex' && service.fetchLyrics && !t.lyrics) {
+        try { t.lyrics = await service.fetchLyrics(t.trackId); } catch {}
+      }
       const result = await service.getAudioUrl(t, {});
       if (!result) throw new Error('audio URL пустой');
       const filename = service.getFilename(t) || `track.mp3`;
@@ -317,6 +322,7 @@ async function downloadByUrl(rawUrl) {
           artist: t.artist || '',
           album: t.album || '',
           year: t.year || '',
+          lyrics: t.lyrics || '',
           flacNative,
           saveAs: saveAs && !isBatch,
         });
@@ -403,6 +409,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       artist: message.artist,
       album: message.album,
       year: message.year,
+      lyrics: message.lyrics,
       flacNative: !!message.flacNative,
       saveAs: !!message.saveAs,
     })

--- a/content.js
+++ b/content.js
@@ -136,6 +136,7 @@
         artist: (track && track.artist) || '',
         album: (track && track.album) || '',
         year: (track && track.year) || '',
+        lyrics: (track && track.lyrics) || '',
         flacNative,
         saveAs: false,
       }, (resp) => {
@@ -165,7 +166,7 @@
         return { success: false, error: 'Нет URL. Переключите трек.' };
       }
       // Дозаполняем coverUri/album/year для тэгов
-      try { await yandex.enrichTrack(track); } catch {}
+      try { const wantLyrics = await new Promise(r => { try { chrome.storage.local.get("yamLyrics", d => r(!!(d && d.yamLyrics))); } catch { r(false); } }); await yandex.enrichTrack(track, { wantLyrics }); } catch {}
       const fn = yandex.getFilename(track) || `track_${info.trackId}.mp3`;
       const dl = await dispatchDownload(result, fn, track);
       if (!dl.success) {
@@ -187,7 +188,7 @@
       const track = { trackId, albumId, title: titleInfo?.title || '', artist: titleInfo?.artist || '', origin: ORIGIN };
       const result = await yandex.getAudioUrl(track, {});
       if (result) {
-        try { await yandex.enrichTrack(track); } catch {}
+        try { const wantLyrics = await new Promise(r => { try { chrome.storage.local.get("yamLyrics", d => r(!!(d && d.yamLyrics))); } catch { r(false); } }); await yandex.enrichTrack(track, { wantLyrics }); } catch {}
         const fn = yandex.getFilename(track) || `track_${trackId}.mp3`;
         const dl = await dispatchDownload(result, fn, track);
         if (!dl.success) {

--- a/desktop/core.py
+++ b/desktop/core.py
@@ -125,6 +125,7 @@ class DownloadWorker(QObject):
         output_dir = self.options.get('output_dir') or str(Path.home() / 'Downloads')
         token = self.options.get('yam_token') or ''
         quality = self.options.get('yam_quality') or 'auto'
+        want_lyrics = bool(self.options.get('yam_lyrics'))
         final_path = yandex_music.download(
             self.url,
             output_dir,
@@ -133,5 +134,6 @@ class DownloadWorker(QObject):
             progress_cb=lambda p: self.progress.emit(self.job_id, p),
             cancel_check=lambda: self._cancel,
             quality=quality,
+            want_lyrics=want_lyrics,
         )
         self.done.emit(self.job_id, final_path)

--- a/desktop/window.py
+++ b/desktop/window.py
@@ -284,6 +284,18 @@ class MainWindow(QMainWindow):
         yam_qual_row.addStretch()
         layout.addLayout(yam_qual_row)
 
+        # Текст песни (Я.Музыка)
+        lyrics_row = QHBoxLayout()
+        self.lyrics_check = QCheckBox('Сохранять текст песни в файл (Я.Музыка)')
+        self.lyrics_check.setToolTip(
+            'Вшивает текст песни в метаданные трека (USLT для MP3, LYRICS для FLAC,\n'
+            '©lyr для M4A). Плееры (AIMP, foobar, PowerAmp) его показывают.'
+        )
+        self.lyrics_check.stateChanged.connect(self._save_settings)
+        lyrics_row.addWidget(self.lyrics_check)
+        lyrics_row.addStretch()
+        layout.addLayout(lyrics_row)
+
         sep = QFrame(); sep.setObjectName('sep'); sep.setFrameShape(QFrame.HLine)
         layout.addWidget(sep)
 
@@ -338,12 +350,14 @@ class MainWindow(QMainWindow):
             if self.yam_quality_combo.itemData(i) == saved_q:
                 self.yam_quality_combo.setCurrentIndex(i)
                 break
+        self.lyrics_check.setChecked(bool(self.settings.get('yam_lyrics', False)))
 
     def _save_settings(self):
         self.settings.set('output_dir', self.dir_edit.text())
         self.settings.set('mode', self.mode_combo.currentIndex())
         self.settings.set('cookies', self.cookies_combo.currentIndex())
         self.settings.set('yam_quality', self.yam_quality_combo.currentData() or 'auto')
+        self.settings.set('yam_lyrics', self.lyrics_check.isChecked())
 
     def _refresh_status(self):
         if self.ffmpeg_path:
@@ -510,6 +524,7 @@ class MainWindow(QMainWindow):
             'cookies_browser': cookies,
             'yam_token': self.settings.get('yam_token', '') or '',
             'yam_quality': self.yam_quality_combo.currentData() or 'auto',
+            'yam_lyrics': self.lyrics_check.isChecked(),
             **mode_opts,
         }
 

--- a/desktop/yandex_music.py
+++ b/desktop/yandex_music.py
@@ -165,6 +165,19 @@ def _fetch_cover_bytes(uri: str, size: str = '600x600') -> Optional[bytes]:
         return None
 
 
+def _fetch_lyrics(track_id: str, token: Optional[str]) -> str:
+    """Текст песни (несинхронный) через /supplement — отдаётся анонимно."""
+    try:
+        data = _api_get(f'/tracks/{track_id}/supplement', token)
+        lyr = data.get('lyrics') if isinstance(data, dict) else None
+        if not lyr:
+            return ''
+        return lyr.get('fullLyrics') or lyr.get('lyrics') or ''
+    except Exception as e:
+        print(f'[YM] lyrics fetch failed: {e}')
+        return ''
+
+
 def _embed_metadata_and_cover(file_path: Path, codec: str, track: dict,
                               cover_bytes: Optional[bytes]) -> None:
     """Прописать ID3 / VorbisComment / MP4-atoms с обложкой и тегами."""
@@ -179,6 +192,7 @@ def _embed_metadata_and_cover(file_path: Path, codec: str, track: dict,
     artist = track.get('artist') or ''
     album = track.get('album') or ''
     year = str(track.get('year') or '') or None
+    lyrics = track.get('lyrics') or ''
 
     is_mp3 = head[:3] == b'ID3' or (len(head) > 1 and head[0] == 0xff and (head[1] & 0xe0) == 0xe0)
     is_flac = head[:4] == b'fLaC'
@@ -186,7 +200,7 @@ def _embed_metadata_and_cover(file_path: Path, codec: str, track: dict,
 
     try:
         if is_mp3 or (codec == 'mp3' and not is_flac and not is_mp4):
-            from mutagen.id3 import ID3, APIC, TIT2, TPE1, TALB, TDRC, ID3NoHeaderError
+            from mutagen.id3 import ID3, APIC, TIT2, TPE1, TALB, TDRC, USLT, ID3NoHeaderError
             try:
                 audio = ID3(file_path)
             except ID3NoHeaderError:
@@ -198,6 +212,9 @@ def _embed_metadata_and_cover(file_path: Path, codec: str, track: dict,
             if artist: audio.add(TPE1(encoding=1, text=artist))
             if album: audio.add(TALB(encoding=1, text=album))
             if year: audio.add(TDRC(encoding=1, text=year))
+            if lyrics:
+                audio.delall('USLT')
+                audio.add(USLT(encoding=1, lang='rus', desc='', text=lyrics))
             if cover_bytes:
                 audio.add(APIC(encoding=0, mime='image/jpeg', type=3, desc='', data=cover_bytes))
             # v2_version=3 — пишем строго ID3v2.3 (Win Explorer читает лучше 2.4)
@@ -209,6 +226,7 @@ def _embed_metadata_and_cover(file_path: Path, codec: str, track: dict,
             if artist: audio['artist'] = artist
             if album: audio['album'] = album
             if year: audio['date'] = year
+            if lyrics: audio['lyrics'] = lyrics
             if cover_bytes:
                 pic = Picture()
                 pic.type = 3  # cover front
@@ -225,6 +243,7 @@ def _embed_metadata_and_cover(file_path: Path, codec: str, track: dict,
             if artist: audio['\xa9ART'] = artist
             if album: audio['\xa9alb'] = album
             if year: audio['\xa9day'] = year
+            if lyrics: audio['\xa9lyr'] = lyrics
             if cover_bytes:
                 audio['covr'] = [MP4Cover(cover_bytes, imageformat=MP4Cover.FORMAT_JPEG)]
             audio.save()
@@ -488,7 +507,8 @@ def download(url: str,
              info_cb: Callable[[dict], None],
              progress_cb: Callable[[dict], None],
              cancel_check: Callable[[], bool],
-             quality: str = 'auto') -> str:
+             quality: str = 'auto',
+             want_lyrics: bool = False) -> str:
     if cancel_check():
         raise YMCancelled()
 
@@ -509,7 +529,7 @@ def download(url: str,
                 'Я.Музыка требует OAuth-токен для скачивания (download-info → 403). '
                 'Получите токен: ' + OAUTH_URL + ' и вставьте в поле «Я.Музыка токен».'
             )
-        return str(_download_one(track, Path(output_dir), token, progress_cb, cancel_check, quality))
+        return str(_download_one(track, Path(output_dir), token, progress_cb, cancel_check, quality, want_lyrics))
 
     # Album / playlist (batch)
     if parsed['type'] == 'album':
@@ -558,7 +578,7 @@ def download(url: str,
         progress_cb({'status': 'downloading', 'message': label,
                      'batch_current': i, 'batch_total': total})
         try:
-            p = _download_one(t, out_dir, token, progress_cb, cancel_check, quality)
+            p = _download_one(t, out_dir, token, progress_cb, cancel_check, quality, want_lyrics)
             last_path = str(p)
         except YMCancelled:
             raise
@@ -570,7 +590,7 @@ def download(url: str,
 
 def _download_one(track: dict, out_dir: Path, token: str,
                   progress_cb: Callable, cancel_check: Callable,
-                  quality: str = 'auto') -> Path:
+                  quality: str = 'auto', want_lyrics: bool = False) -> Path:
     if cancel_check():
         raise YMCancelled()
     result = _resolve_audio_url(track, token, quality)
@@ -659,6 +679,8 @@ def _download_one(track: dict, out_dir: Path, token: str,
                 print(f'[YM] rename failed: {e}')
 
     # Вшиваем теги и обложку (mutagen сам детектит формат по магии).
+    if want_lyrics and not track.get('lyrics'):
+        track['lyrics'] = _fetch_lyrics(track['trackId'], token)
     cover_uri = track.get('coverUri') or ''
     cover_bytes = _fetch_cover_bytes(cover_uri) if cover_uri else None
     _embed_metadata_and_cover(out_path, codec, track, cover_bytes)

--- a/lib/flacremux.js
+++ b/lib/flacremux.js
@@ -129,6 +129,7 @@
     const add = (k, v) => { if (v) comments.push(enc.encode(k + '=' + String(v))); };
     add('TITLE', opts.title); add('ARTIST', opts.artist);
     add('ALBUM', opts.album); add('DATE', opts.year);
+    add('LYRICS', opts.lyrics);  // несинхронный текст (стандартное поле)
     const parts = [le32a(vendor.length), vendor, le32a(comments.length)];
     for (const c of comments) { parts.push(le32a(c.length)); parts.push(c); }
     const payload = concat(parts.map(x => x instanceof Uint8Array ? x : new Uint8Array(x)));
@@ -169,7 +170,7 @@
     const out = [new Uint8Array([0x66, 0x4c, 0x61, 0x43])]; // 'fLaC'
     const meta = [];
     meta.push({ kind: 'streaminfo', bytes: si });
-    if (opts.title || opts.artist || opts.album || opts.year) {
+    if (opts.title || opts.artist || opts.album || opts.year || opts.lyrics) {
       meta.push({ kind: 'vorbis', bytes: vorbisCommentBlock(opts, false) });
     }
     if (opts.cover) {

--- a/lib/id3.js
+++ b/lib/id3.js
@@ -72,13 +72,27 @@
     return concat(head, body);
   }
 
+  // USLT — несинхронный текст песни. body: [enc][lang 3][descriptor+term][lyrics]
+  function usltFrame(lyrics) {
+    // encoding 0x01 (UTF-16) для кириллицы. descriptor пустой = BOM+терминатор.
+    const body = concat(
+      new Uint8Array([0x01]),                 // UTF-16 encoding
+      asciiBytes('rus'),                       // language (ISO-639-2)
+      new Uint8Array([0xff, 0xfe, 0x00, 0x00]),// пустой descriptor: BOM + UTF-16 terminator
+      utf16leWithBom(lyrics),                  // сам текст
+    );
+    const head = concat(asciiBytes('USLT'), be32(body.length), new Uint8Array([0, 0]));
+    return concat(head, body);
+  }
+
   function buildID3v2(opts) {
-    // opts: { title, artist, album, year, cover (Uint8Array), coverMime }
+    // opts: { title, artist, album, year, cover (Uint8Array), coverMime, lyrics }
     const frames = [];
     if (opts.title)  frames.push(textFrame('TIT2', opts.title));
     if (opts.artist) frames.push(textFrame('TPE1', opts.artist));
     if (opts.album)  frames.push(textFrame('TALB', opts.album));
     if (opts.year)   frames.push(textFrame('TDRC', String(opts.year)));
+    if (opts.lyrics) frames.push(usltFrame(opts.lyrics));
     if (opts.cover)  frames.push(apicFrame(opts.cover, opts.coverMime || 'image/jpeg'));
 
     const body = concat(...frames);

--- a/lib/mp4cover.js
+++ b/lib/mp4cover.js
@@ -73,6 +73,7 @@
     if (opts.artist) items.push(metaItem('©ART', dataAtom(1, utf8(opts.artist))));
     if (opts.album)  items.push(metaItem('©alb', dataAtom(1, utf8(opts.album))));
     if (opts.year)   items.push(metaItem('©day', dataAtom(1, utf8(String(opts.year)))));
+    if (opts.lyrics) items.push(metaItem('©lyr', dataAtom(1, utf8(opts.lyrics))));
     if (opts.cover) {
       const fmt = (opts.coverMime === 'image/png') ? 14 : 13; // 13=jpeg,14=png
       items.push(metaItem('covr', dataAtom(fmt, opts.cover)));

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Music Downloader (Я.Музыка / Bandcamp / SoundCloud)",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Скачивайте треки, альбомы и плейлисты с Яндекс Музыки, Bandcamp и SoundCloud — на странице или по ссылке из попапа.",
   "permissions": [
     "activeTab",

--- a/popup.html
+++ b/popup.html
@@ -69,6 +69,14 @@
       <input type="checkbox" id="flac-native-toggle" class="toggle-check" checked>
     </div>
 
+    <div class="setting-row quality-row" id="lyrics-row">
+      <label class="toggle-label" for="lyrics-toggle">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="6" x2="20" y2="6"/><line x1="4" y1="12" x2="14" y2="12"/><line x1="4" y1="18" x2="18" y2="18"/></svg>
+        Сохранять текст песни <span class="muted">(Я.Музыка)</span>
+      </label>
+      <input type="checkbox" id="lyrics-toggle" class="toggle-check">
+    </div>
+
     <details class="quality-help">
       <summary>что выбрать?</summary>
       <div class="quality-help-body">

--- a/popup.js
+++ b/popup.js
@@ -42,6 +42,17 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  // ═══ Lyrics toggle ═══
+  const lyricsToggle = document.getElementById('lyrics-toggle');
+  if (lyricsToggle) {
+    chrome.storage.local.get('yamLyrics', (data) => {
+      lyricsToggle.checked = !!(data && data.yamLyrics);  // default off
+    });
+    lyricsToggle.addEventListener('change', () => {
+      chrome.storage.local.set({ yamLyrics: lyricsToggle.checked });
+    });
+  }
+
   // ═══ Current track (Yandex only, via content script) ═══
   chrome.runtime.sendMessage({ action: 'getCurrentTrack' }, (resp) => {
     if (chrome.runtime.lastError) return;

--- a/services/yandex.js
+++ b/services/yandex.js
@@ -223,20 +223,33 @@
     return { trackId: String(trackId), albumId: albumId || '', title: '', artist: '' };
   }
 
-  // Дозаполнение track-метадата (cover/album/year) — для in-page кнопок где
+  // Текст песни (несинхронный) — /supplement отдаёт анонимно
+  async function fetchLyrics(trackId) {
+    try {
+      const data = await apiGet(`/tracks/${trackId}/supplement`, await getToken());
+      const lyr = data?.lyrics;
+      if (!lyr) return '';
+      return lyr.fullLyrics || lyr.lyrics || '';
+    } catch (e) { console.warn('[YMD] lyrics fetch failed:', e.message); return ''; }
+  }
+
+  // Дозаполнение track-метадата (cover/album/year/lyrics) — для in-page кнопок где
   // у нас только trackId/albumId/title/artist из DOM, без coverUri.
-  async function enrichTrack(track) {
-    if (track && track.coverUri && track.album) return track; // уже есть
+  async function enrichTrack(track, opts) {
     if (!track || !track.trackId) return track;
     try {
       const token = await getToken();
-      const enriched = await fetchSingleTrack(track.trackId, track.albumId, token);
-      // Сохраняем переданные title/artist если они уже есть (более точные из DOM)
-      track.coverUri = track.coverUri || enriched.coverUri || '';
-      track.album = track.album || enriched.album || '';
-      track.year = track.year || enriched.year || '';
-      track.title = track.title || enriched.title || '';
-      track.artist = track.artist || enriched.artist || '';
+      if (!track.coverUri || !track.album) {
+        const enriched = await fetchSingleTrack(track.trackId, track.albumId, token);
+        track.coverUri = track.coverUri || enriched.coverUri || '';
+        track.album = track.album || enriched.album || '';
+        track.year = track.year || enriched.year || '';
+        track.title = track.title || enriched.title || '';
+        track.artist = track.artist || enriched.artist || '';
+      }
+      if (opts?.wantLyrics && !track.lyrics) {
+        track.lyrics = await fetchLyrics(track.trackId);
+      }
     } catch (e) { console.warn('[YMD] enrichTrack failed:', e.message); }
     return track;
   }
@@ -371,6 +384,7 @@
     listTracks,
     getAudioUrl,
     enrichTrack,
+    fetchLyrics,
     getFilename(track) {
       const ext = extForCodec(track && track._codec);
       return globalThis.YMD.utils.makeFilename(track.artist, track.title, ext) ||


### PR DESCRIPTION
Юзер попросил вшивать текст прямо в трек. Я.Музыка отдаёт текст анонимно через /tracks/{id}/supplement.

## Вшивание во все форматы
- MP3 → ID3 USLT frame (UTF-16)
- FLAC → VorbisComment LYRICS
- M4A → ©lyr atom

Плееры (AIMP, foobar, PowerAmp) показывают.

## UI
Чекбокс «Сохранять текст песни» (расширение + десктоп), default off.

## Проверено
USLT с кириллицей + переносами строк вшивается и читается mutagen корректно.