### PR TITLE
v3.8.1: фикс нативного FLAC в расширении (offscreen blob + const bug)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
             background.js \
             content.js content.css \
             popup.html popup.js popup.css \
+            offscreen.html offscreen.js \
             lib services inject icons \
             README.md
           echo "out=out/${OUT}" >> "$GITHUB_OUTPUT"

--- a/background.js
+++ b/background.js
@@ -140,7 +140,7 @@ async function downloadAndTag(opts) {
   // Определяем РЕАЛЬНЫЙ контейнер по магическим байтам — поле codec из API
   // ненадёжно (Яндекс зовёт flac-mp4 «flac», но это MP4-контейнер, не нативный
   // FLAC). Сохранять MP4 как .flac → FLAC-декодеры выдают LOST_SYNC / "Not a flac".
-  const realContainer = detectContainer(bytes);  // 'flac' | 'm4a' | 'mp3' | 'unknown'
+  let realContainer = detectContainer(bytes);  // 'flac' | 'm4a' | 'mp3' | 'unknown'
   const debug = { codec: opts.codec || '', container: realContainer, coverUri: opts.coverUri || '', coverBytes: 0, tagged: false };
 
   // Чиним расширение файла под реальный контейнер
@@ -211,21 +211,86 @@ async function downloadAndTag(opts) {
     }
   }
 
-  // base64 → data URL → chrome.downloads
-  const chunkSize = 0x8000;
-  let binary = '';
-  for (let i = 0; i < bytes.length; i += chunkSize) {
-    binary += String.fromCharCode.apply(null, bytes.subarray(i, i + chunkSize));
-  }
-  const base64 = btoa(binary);
-  const dataUrl = `data:application/octet-stream;base64,${base64}`;
-
-  return new Promise(resolve => {
-    chrome.downloads.download({ url: dataUrl, filename: opts.filename, saveAs: !!opts.saveAs }, (id) => {
-      if (chrome.runtime.lastError) resolve({ ok: false, error: chrome.runtime.lastError.message, debug });
-      else resolve({ ok: true, downloadId: id, size: bytes.length, debug });
+  // Сохранение через blob: URL (offscreen document). Для маленьких файлов
+  // (<5 МБ) фоллбэк на data: URL если offscreen почему-то недоступен.
+  const blobId = 'ymd-' + (++blobCounter);
+  try {
+    const url = await makeBlobUrlViaOffscreen(blobId, bytes, 'application/octet-stream');
+    const id = await new Promise((resolve, reject) => {
+      chrome.downloads.download({ url, filename: opts.filename, saveAs: !!opts.saveAs }, (downloadId) => {
+        if (chrome.runtime.lastError) reject(new Error(chrome.runtime.lastError.message));
+        else resolve(downloadId);
+      });
     });
+    // Revoke после завершения скачивания (или по таймеру как страховка)
+    revokeBlobUrlLater(blobId, id);
+    debug.via = 'offscreen-blob';
+    return { ok: true, downloadId: id, size: bytes.length, debug };
+  } catch (e) {
+    console.warn('[YMD] offscreen blob failed, fallback to data URL:', e.message);
+    // Фоллбэк: data URL (работает для небольших файлов)
+    let binary = '';
+    const chunkSize = 0x8000;
+    for (let i = 0; i < bytes.length; i += chunkSize) {
+      binary += String.fromCharCode.apply(null, bytes.subarray(i, i + chunkSize));
+    }
+    const dataUrl = `data:application/octet-stream;base64,${btoa(binary)}`;
+    return new Promise(resolve => {
+      chrome.downloads.download({ url: dataUrl, filename: opts.filename, saveAs: !!opts.saveAs }, (id) => {
+        if (chrome.runtime.lastError) resolve({ ok: false, error: chrome.runtime.lastError.message, debug });
+        else { debug.via = 'data-url'; resolve({ ok: true, downloadId: id, size: bytes.length, debug }); }
+      });
+    });
+  }
+}
+
+// ─────────────────────── OFFSCREEN BLOB HELPER ───────────────────────
+let blobCounter = 0;
+
+async function ensureOffscreen() {
+  // hasDocument есть не во всех версиях — пробуем, иначе ловим "already exists"
+  try {
+    if (chrome.offscreen.hasDocument) {
+      const has = await chrome.offscreen.hasDocument();
+      if (has) return;
+    }
+  } catch {}
+  try {
+    await chrome.offscreen.createDocument({
+      url: 'offscreen.html',
+      reasons: ['BLOBS'],
+      justification: 'Создание blob: URL для сохранения больших аудио-файлов (FLAC).',
+    });
+  } catch (e) {
+    // "Only a single offscreen document may be created" — значит уже есть, ок.
+    if (!/single offscreen|already/i.test(e.message || '')) throw e;
+  }
+}
+
+async function makeBlobUrlViaOffscreen(id, bytes, mime) {
+  if (!chrome.offscreen) throw new Error('offscreen API недоступен');
+  await ensureOffscreen();
+  const resp = await chrome.runtime.sendMessage({
+    target: 'offscreen', action: 'makeBlobUrl', id, bytes, mime,
   });
+  if (!resp || !resp.ok) throw new Error(resp?.error || 'makeBlobUrl failed');
+  return resp.url;
+}
+
+function revokeBlobUrlLater(id, downloadId) {
+  // Revoke когда скачивание завершилось
+  const onChanged = (delta) => {
+    if (delta.id === downloadId && delta.state &&
+        (delta.state.current === 'complete' || delta.state.current === 'interrupted')) {
+      chrome.downloads.onChanged.removeListener(onChanged);
+      chrome.runtime.sendMessage({ target: 'offscreen', action: 'revokeBlobUrl', id }).catch(() => {});
+    }
+  };
+  chrome.downloads.onChanged.addListener(onChanged);
+  // Страховка: revoke через 5 минут в любом случае
+  setTimeout(() => {
+    chrome.runtime.sendMessage({ target: 'offscreen', action: 'revokeBlobUrl', id }).catch(() => {});
+  }, 5 * 60 * 1000);
 }
 
 // Определение реального аудио-контейнера по магическим байтам.

--- a/content.js
+++ b/content.js
@@ -142,12 +142,14 @@
       }, (resp) => {
         if (resp?.debug) {
           const d = resp.debug;
-          console.log('[YMD] tag debug — codec:', d.codec, '| coverUri:', d.coverUri ? 'есть' : 'НЕТ',
+          console.log('[YMD] tag debug — codec:', d.codec, '| container:', d.container,
+            '| remuxed:', d.remuxed, '| via:', d.via, '| filename:', d.filename,
             '| coverBytes:', d.coverBytes, '| tagged:', d.tagged,
             d.coverError ? '| coverError: ' + d.coverError : '',
-            d.tagError ? '| tagError: ' + d.tagError : '');
+            d.tagError ? '| tagError: ' + d.tagError : '',
+            d.remuxError ? '| remuxError: ' + d.remuxError : '');
         }
-        if (chrome.runtime.lastError) resolve({ success: false, error: chrome.runtime.lastError.message });
+        if (chrome.runtime.lastError) { console.error('[YMD] download error:', chrome.runtime.lastError.message); resolve({ success: false, error: chrome.runtime.lastError.message }); }
         else if (resp?.ok) resolve({ success: true, filename });
         else resolve({ success: false, error: resp?.error || 'download failed' });
       });

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Music Downloader (Я.Музыка / Bandcamp / SoundCloud)",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Скачивайте треки, альбомы и плейлисты с Яндекс Музыки, Bandcamp и SoundCloud — на странице или по ссылке из попапа.",
   "permissions": [
     "activeTab",
@@ -9,6 +9,7 @@
     "storage",
     "scripting",
     "tabs",
+    "offscreen",
     "webRequest"
   ],
   "host_permissions": [

--- a/offscreen.html
+++ b/offscreen.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body><script src="offscreen.js"></script></body>
+</html>

--- a/offscreen.js
+++ b/offscreen.js
@@ -1,0 +1,32 @@
+// Offscreen document — единственная задача: превратить байты в blob: URL.
+// MV3 service worker НЕ имеет URL.createObjectURL, а data: URL имеет лимит
+// (~немного МБ) — большие FLAC через него не качаются. Offscreen-документ это
+// обычный DOM-контекст, тут createObjectURL работает для файлов любого размера.
+
+const blobUrls = new Map();  // id → url (чтобы потом revoke)
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.target !== 'offscreen') return;
+
+  if (msg.action === 'makeBlobUrl') {
+    try {
+      // msg.bytes приходит как обычный массив/Uint8Array (структурированное
+      // клонирование). Собираем Blob и отдаём blob: URL.
+      const u8 = msg.bytes instanceof Uint8Array ? msg.bytes : new Uint8Array(msg.bytes);
+      const blob = new Blob([u8], { type: msg.mime || 'application/octet-stream' });
+      const url = URL.createObjectURL(blob);
+      blobUrls.set(msg.id, url);
+      sendResponse({ ok: true, url });
+    } catch (e) {
+      sendResponse({ ok: false, error: e.message || String(e) });
+    }
+    return true;
+  }
+
+  if (msg.action === 'revokeBlobUrl') {
+    const url = blobUrls.get(msg.id);
+    if (url) { try { URL.revokeObjectURL(url); } catch {} blobUrls.delete(msg.id); }
+    sendResponse({ ok: true });
+    return true;
+  }
+});


### PR DESCRIPTION
Два бага мешали скачать нативный FLAC через расширение:

1. **data URL лимит** — большой FLAC (40-50МБ → base64 67МБ) не качался. Фикс: offscreen document + blob URL (MV3-способ без лимита). Фолбэк на data URL для мелких.

2. **const realContainer** переприсваивался на 'flac' → 'Assignment to constant variable' → ремукс падал → фолбэк на .m4a без обложки. Фикс: let.

Проверено на реальном файле (23МБ): fLaC, decode 0 ошибок, lossless 44.1/16, теги+обложка, спектрограмма до 22кГц.