### PR TITLE
v3.10.0: Win7-версия стала полной (Яндекс + yt-dlp 1800 сайтов)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
         run: |
           python -m py_compile downloader.py
           python -m py_compile desktop/main.py desktop/window.py desktop/core.py desktop/settings.py desktop/ffmpeg_helper.py desktop/build.py desktop/yandex_music.py desktop/ffmpeg_installer.py
-          python -m py_compile lite/main.py lite/yandex_music.py lite/ffmpeg_helper.py lite/build.py
+          python -m py_compile lite/main.py lite/yandex_music.py lite/ffmpeg_helper.py lite/ytdlp_worker.py lite/build.py

--- a/README.md
+++ b/README.md
@@ -97,7 +97,13 @@ python main.py
 
 ### 🪟 Версия для Windows 7
 
-Для Win7 есть отдельная лёгкая программа **`MusicDownloader-Lite.exe`** (в [Releases](https://github.com/vladimir120307-droid/yandex-music-downloader/releases/latest)) — только Яндекс.Музыка (FLAC / MP3 + обложка + теги + текст), на tkinter. Подробности — [lite/README.md](lite/README.md).
+Для Win7 есть отдельная программа **`MusicDownloader-Lite.exe`** (в [Releases](https://github.com/vladimir120307-droid/yandex-music-downloader/releases/latest)) на tkinter:
+- **Яндекс.Музыка** — FLAC / MP3 + обложка + теги + текст (наш движок, работает всегда)
+- **YouTube / SoundCloud / Bandcamp / VK** — через yt-dlp 2024.10.22 (последний с Python 3.8)
+
+> ⚠️ YouTube на Win7-версии может не работать — yt-dlp для Python 3.8 устарел (~окт 2024), а YouTube часто меняет защиту. Стабильные сайты и Яндекс работают. Для надёжного YouTube — десктоп на Win10+.
+
+Подробности — [lite/README.md](lite/README.md).
 
 ---
 

--- a/lite/README.md
+++ b/lite/README.md
@@ -1,12 +1,13 @@
-# Music Downloader Lite (для Windows 7)
+# Music Downloader для Windows 7
 
-Облегчённая версия **специально для Windows 7**, где полный десктоп (на PySide6) не запускается.
+Полнофункциональная версия **для Windows 7**, где основной десктоп (на PySide6) не запускается. GUI на **tkinter** (работает на Win7).
 
-- Только **Яндекс.Музыка**: FLAC / MP3 320 + обложка + теги + текст песни
-- GUI на **tkinter** (встроен в Python, работает на Win7)
-- Переиспользует тот же движок что и полный десктоп (`yandex_music.py`)
+- **Яндекс.Музыка** — FLAC / MP3 320 + обложка + теги + текст песни (наш движок `yandex_music.py`)
+- **YouTube, SoundCloud, Bandcamp, VK и др.** — через yt-dlp
 
-> Нужна полная версия (1800 сайтов: YouTube, SoundCloud, VK…)? Она в [`desktop/`](../desktop) — но требует Windows 10+.
+> ⚠️ **Важно про yt-dlp:** Win7 застрял на Python 3.8, а свежий yt-dlp требует 3.10+. Поэтому здесь закреплён **yt-dlp 2024.10.22** — последний с поддержкой 3.8. Стабильные сайты (Bandcamp, SoundCloud, VK) работают, но **YouTube может не качаться** (он часто меняет защиту, а старый экстрактор не обновляется). Яндекс.Музыка работает всегда — она на нашем коде, не на yt-dlp.
+>
+> Нужен надёжный YouTube? Используй [полный десктоп](../desktop) на Windows 10+.
 
 ## Запуск из исходников
 
@@ -21,30 +22,33 @@ python main.py
 ## Сборка .exe
 
 ```bash
-pip install pyinstaller mutagen pycryptodome pillow
+pip install pyinstaller pillow
 python build.py
 ```
 
-Результат: `dist/MusicDownloader-Lite.exe` (~15-20 МБ). Собирай на **Python 3.8**, иначе exe не пойдёт на Win7.
+Результат: `dist/MusicDownloader-Lite.exe`. Собирай на **Python 3.8**, иначе exe не пойдёт на Win7.
 
 ## Использование
 
 1. Запусти программу
-2. Нажми **«Получить»** → залогинься в Яндекс → скопируй токен (или весь URL) → **«Сохранить»**
-3. Вставь ссылку на трек / альбом / плейлист Я.Музыки
-4. Выбери качество (Авто / FLAC / MP3 320), при желании включи «Текст песни»
+2. Для Яндекс.Музыки: **«Получить»** → залогинься → скопируй токен (или URL) → **«Сохранить»**
+3. Вставь ссылку (Я.Музыка / YouTube / SoundCloud / Bandcamp / VK …)
+4. Выбери формат:
+   - **Я.Музыка** — Авто / FLAC / MP3 320 (+ галка «Текст песни»)
+   - **Др. сайты** — MP3 / M4A / FLAC / Opus / видео
 5. **«Скачать»**
 
-## FLAC
+## ffmpeg
 
-- **Нужен Я.Плюс** для lossless
-- Для **нативного `.flac`** положи `ffmpeg.exe` рядом с программой (или в PATH) — она переупакует FLAC-в-MP4 в настоящий `.flac` без потери качества
-- Без ffmpeg FLAC сохранится как `.m4a` (тот же lossless, играется везде)
+Нужен для:
+- нативного `.flac` из Я.Музыки (без него FLAC сохранится как `.m4a`)
+- конвертации с YouTube / SoundCloud / видео
 
-ffmpeg для Win7: [yt-dlp/FFmpeg-Builds](https://github.com/yt-dlp/FFmpeg-Builds/releases) → `ffmpeg-master-latest-win64-gpl.zip` → `ffmpeg.exe` из `bin/` положить рядом.
+Положи `ffmpeg.exe` рядом с программой или в PATH. Где взять: [yt-dlp/FFmpeg-Builds](https://github.com/yt-dlp/FFmpeg-Builds/releases) → `ffmpeg-master-latest-win64-gpl.zip` → `ffmpeg.exe` из `bin/`.
 
 ## Зависимости
 
 - `mutagen` — теги и обложка
-- `pycryptodome` — расшифровка FLAC-потока (AES-CTR)
+- `pycryptodome` — расшифровка FLAC (AES-CTR)
+- `yt-dlp==2024.10.22` — другие сайты (последний с Python 3.8)
 - `tkinter` — встроен в Python

--- a/lite/main.py
+++ b/lite/main.py
@@ -23,6 +23,22 @@ from tkinter import ttk, filedialog, messagebox
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import yandex_music
+try:
+    import ytdlp_worker
+    HAS_YTDLP = True
+except Exception:
+    HAS_YTDLP = False
+
+# Форматы для yt-dlp (не-Яндекс сайты)
+YTDLP_FORMATS = [
+    ('Аудио · MP3 320', dict(audio_format='mp3', audio_quality='320', video='')),
+    ('Аудио · M4A',     dict(audio_format='m4a', audio_quality='0', video='')),
+    ('Аудио · FLAC',    dict(audio_format='flac', audio_quality='0', video='')),
+    ('Аудио · Opus',    dict(audio_format='opus', audio_quality='0', video='')),
+    ('Видео · Лучшее',  dict(audio_format='', audio_quality='', video='best')),
+    ('Видео · 1080p',   dict(audio_format='', audio_quality='', video='1080')),
+    ('Видео · 720p',    dict(audio_format='', audio_quality='', video='720')),
+]
 
 OAUTH_URL = (
     'https://oauth.yandex.ru/authorize?response_type=token'
@@ -84,10 +100,11 @@ class App:
         # Заголовок
         head = tk.Frame(self.root, bg=BG)
         head.pack(fill='x', pady=(14, 6), **pad)
-        tk.Label(head, text='🎵 Music Downloader Lite', bg=BG, fg=YELLOW,
+        tk.Label(head, text='🎵 Music Downloader (Windows 7)', bg=BG, fg=YELLOW,
                  font=('Segoe UI', 16, 'bold')).pack(anchor='w')
-        tk.Label(head, text='Яндекс.Музыка · FLAC / MP3 · обложка · теги · текст',
-                 bg=BG, fg=GREY, font=('Segoe UI', 9)).pack(anchor='w')
+        sub = ('Яндекс.Музыка (FLAC/MP3) + YouTube · SoundCloud · Bandcamp · VK · и др.'
+               if HAS_YTDLP else 'Яндекс.Музыка · FLAC / MP3 · обложка · теги · текст')
+        tk.Label(head, text=sub, bg=BG, fg=GREY, font=('Segoe UI', 9)).pack(anchor='w')
 
         # Токен
         self._section('Токен Яндекс.Музыки (нужен один раз):')
@@ -111,17 +128,26 @@ class App:
         ue.pack(fill='x', ipady=5, **pad)
         ue.bind('<Return>', lambda e: self.start())
 
-        # Качество + текст
+        # Качество Я.Музыки + текст
         opt = tk.Frame(self.root, bg=BG); opt.pack(fill='x', pady=(10, 0), **pad)
-        tk.Label(opt, text='Качество:', bg=BG, fg=WHITE, font=('Segoe UI', 9)).pack(side='left')
+        tk.Label(opt, text='Я.Музыка:', bg=BG, fg=WHITE, font=('Segoe UI', 9)).pack(side='left')
         self.quality_var = tk.StringVar(value=self.settings.get('quality', 'auto'))
-        qbox = ttk.Combobox(opt, textvariable=self.quality_var, state='readonly', width=28,
-                            values=['auto', 'flac', 'mp3-320'])
-        qbox.pack(side='left', padx=(6, 16))
+        ttk.Combobox(opt, textvariable=self.quality_var, state='readonly', width=20,
+                     values=['auto', 'flac', 'mp3-320']).pack(side='left', padx=(6, 16))
         self.lyrics_var = tk.BooleanVar(value=self.settings.get('lyrics', '0') == '1')
         tk.Checkbutton(opt, text='Текст песни', variable=self.lyrics_var, bg=BG, fg=WHITE,
                        selectcolor=BG2, activebackground=BG, activeforeground=WHITE,
                        font=('Segoe UI', 9)).pack(side='left')
+
+        # Формат для других сайтов (yt-dlp)
+        if HAS_YTDLP:
+            opt2 = tk.Frame(self.root, bg=BG); opt2.pack(fill='x', pady=(6, 0), **pad)
+            tk.Label(opt2, text='Др. сайты:', bg=BG, fg=WHITE, font=('Segoe UI', 9)).pack(side='left')
+            self.ytfmt_var = tk.StringVar(value=self.settings.get('ytfmt', YTDLP_FORMATS[0][0]))
+            ttk.Combobox(opt2, textvariable=self.ytfmt_var, state='readonly', width=20,
+                         values=[n for n, _ in YTDLP_FORMATS]).pack(side='left', padx=(6, 8))
+            tk.Label(opt2, text='(YouTube/SoundCloud/Bandcamp/VK — нужен ffmpeg)',
+                     bg=BG, fg=GREY, font=('Segoe UI', 8)).pack(side='left')
 
         # Папка
         self._section('Папка для сохранения:')
@@ -196,35 +222,54 @@ class App:
         url = self.url_var.get().strip()
         token = self.token_var.get().strip()
         if not url:
-            messagebox.showwarning('Внимание', 'Вставь ссылку на трек/альбом/плейлист'); return
-        if not token:
+            messagebox.showwarning('Внимание', 'Вставь ссылку'); return
+        is_yandex = yandex_music.is_yandex_music_url(url)
+        if is_yandex and not token:
             if messagebox.askyesno('Нужен токен',
-                                    'Для скачивания нужен токен Я.Музыки. Открыть страницу получения?'):
+                                    'Для Яндекс.Музыки нужен токен. Открыть страницу получения?'):
                 self._open_oauth()
+            return
+        if not is_yandex and not HAS_YTDLP:
+            messagebox.showerror('Не поддерживается',
+                                 'yt-dlp не установлен — другие сайты недоступны. Только Яндекс.Музыка.')
             return
         # Сохраняем настройки
         self.settings.update({'quality': self.quality_var.get(), 'dir': self.dir_var.get(),
                               'lyrics': '1' if self.lyrics_var.get() else '0'})
+        if HAS_YTDLP:
+            self.settings['ytfmt'] = self.ytfmt_var.get()
         save_settings(self.settings)
 
         self._cancel = False
         self.dl_btn.config(text='Остановить')
         self.prog['value'] = 0
-        threading.Thread(target=self._work, args=(url, token), daemon=True).start()
+        threading.Thread(target=self._work, args=(url, token, is_yandex), daemon=True).start()
 
-    def _work(self, url, token):
+    def _work(self, url, token, is_yandex):
         try:
             self._set_status('Получаю данные…')
-            yandex_music.download(
-                url, self.dir_var.get(), token=token,
-                info_cb=self._on_info, progress_cb=self._on_progress,
-                cancel_check=lambda: self._cancel,
-                quality=self.quality_var.get(),
-                want_lyrics=self.lyrics_var.get(),
-            )
+            if is_yandex:
+                yandex_music.download(
+                    url, self.dir_var.get(), token=token,
+                    info_cb=self._on_info, progress_cb=self._on_progress,
+                    cancel_check=lambda: self._cancel,
+                    quality=self.quality_var.get(),
+                    want_lyrics=self.lyrics_var.get(),
+                )
+            else:
+                from ffmpeg_helper import find_ffmpeg
+                fmt = dict(YTDLP_FORMATS)[self.ytfmt_var.get()]
+                ytdlp_worker.download(
+                    url, self.dir_var.get(),
+                    audio_format=fmt['audio_format'], audio_quality=fmt['audio_quality'],
+                    video_max_height=fmt['video'], ffmpeg_path=find_ffmpeg(),
+                    cookies_browser=None,
+                    info_cb=self._on_info, progress_cb=self._on_progress,
+                    cancel_check=lambda: self._cancel,
+                )
             self._set_status('Готово!'); self.prog['value'] = 100
             self._log('✓ Скачивание завершено')
-        except yandex_music.YMCancelled:
+        except (yandex_music.YMCancelled,) + ((ytdlp_worker.YtCancelled,) if HAS_YTDLP else ()):
             self._set_status('Отменено'); self._log('Отменено пользователем')
         except Exception as e:
             self._set_status('Ошибка: ' + str(e)[:80])

--- a/lite/requirements.txt
+++ b/lite/requirements.txt
@@ -1,2 +1,4 @@
 mutagen>=1.45.0
 pycryptodome>=3.18.0
+# yt-dlp 2024.10.22 — последняя версия с поддержкой Python 3.8 (Windows 7)
+yt-dlp==2024.10.22

--- a/lite/ytdlp_worker.py
+++ b/lite/ytdlp_worker.py
@@ -1,0 +1,98 @@
+"""Обёртка над yt-dlp для Win7-версии (Python 3.8).
+
+Используется для всех сайтов КРОМЕ Яндекс.Музыки (та через yandex_music.py).
+yt-dlp закреплён на 2024.10.22 — последняя версия с поддержкой Python 3.8.
+Поэтому экстракторы ~октября 2024: стабильные сайты (Bandcamp, SoundCloud,
+VK) работают, YouTube может ломаться (часто меняет защиту).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Optional
+
+
+class YtCancelled(Exception):
+    pass
+
+
+def is_supported(url: str) -> bool:
+    """yt-dlp поддерживает почти всё. Грубая проверка что это http(s) ссылка."""
+    u = (url or '').strip().lower()
+    return u.startswith('http://') or u.startswith('https://')
+
+
+def download(url: str,
+             output_dir: str,
+             audio_format: str,        # 'mp3' | 'm4a' | 'flac' | 'opus' | '' (видео)
+             audio_quality: str,       # '320' | '192' | '0'
+             video_max_height: str,    # '' для аудио, иначе 'best'/'1080'/'720'/'480'
+             ffmpeg_path: Optional[str],
+             cookies_browser: Optional[str],
+             info_cb: Callable[[dict], None],
+             progress_cb: Callable[[dict], None],
+             cancel_check: Callable[[], bool]) -> str:
+    try:
+        import yt_dlp
+    except ImportError:
+        raise RuntimeError('yt-dlp не установлен. pip install "yt-dlp==2024.10.22"')
+
+    out_tmpl = str(Path(output_dir) / '%(uploader,channel,artist|Unknown)s - %(title).100s.%(ext)s')
+
+    def hook(d):
+        if cancel_check():
+            raise YtCancelled()
+        progress_cb(d)
+
+    opts = {
+        'outtmpl': out_tmpl,
+        'progress_hooks': [hook],
+        'quiet': True,
+        'no_warnings': True,
+        'noprogress': True,
+        'retries': 3,
+        'fragment_retries': 3,
+        'concurrent_fragment_downloads': 4,
+    }
+    if ffmpeg_path:
+        opts['ffmpeg_location'] = ffmpeg_path
+    if cookies_browser:
+        opts['cookiesfrombrowser'] = (cookies_browser,)
+
+    if video_max_height:
+        if video_max_height == 'best':
+            opts['format'] = 'bestvideo*+bestaudio/best'
+        else:
+            opts['format'] = f'bestvideo[height<={video_max_height}]+bestaudio/best[height<={video_max_height}]'
+        opts['merge_output_format'] = 'mp4'
+        opts['postprocessors'] = [{'key': 'FFmpegMetadata'}]
+    else:
+        opts['format'] = 'bestaudio/best'
+        pps = [{
+            'key': 'FFmpegExtractAudio',
+            'preferredcodec': audio_format or 'mp3',
+            'preferredquality': audio_quality or '0',
+        }, {'key': 'FFmpegMetadata'}, {'key': 'EmbedThumbnail'}]
+        opts['postprocessors'] = pps
+        opts['writethumbnail'] = True
+
+    final_path = ''
+    with yt_dlp.YoutubeDL(opts) as ydl:
+        info = ydl.extract_info(url, download=False)
+        if cancel_check():
+            raise YtCancelled()
+        if info:
+            info_cb({
+                'title': info.get('title', ''),
+                'uploader': info.get('uploader') or info.get('channel') or info.get('artist') or '',
+                'extractor': info.get('extractor_key') or info.get('extractor') or '',
+            })
+        ydl.download([url])
+        if info:
+            try:
+                final_path = ydl.prepare_filename(info)
+                if not video_max_height:
+                    final_path = str(Path(final_path).with_suffix('.' + (audio_format or 'mp3')))
+            except Exception:
+                final_path = ''
+    progress_cb({'status': 'finished'})
+    return final_path

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Music Downloader (Я.Музыка / Bandcamp / SoundCloud)",
-  "version": "3.9.2",
+  "version": "3.10.0",
   "description": "Скачивайте треки, альбомы и плейлисты с Яндекс Музыки, Bandcamp и SoundCloud — на странице или по ссылке из попапа.",
   "permissions": [
     "activeTab",


### PR DESCRIPTION
Юзер попросил полное приложение под Win7. Расширил Lite (tkinter):

- **ytdlp_worker.py** — yt-dlp для не-Яндекс сайтов (YouTube, SoundCloud, Bandcamp, VK)
- **main.py** — детект Яндекс (наш движок) vs другие (yt-dlp) + селектор формата
- **yt-dlp==2024.10.22** — последний с Python 3.8 (Win7)

⚠️ YouTube может не работать (старый yt-dlp), стабильные сайты + Яндекс — да. Честно указано в README.